### PR TITLE
Add support for FX pools

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,11 @@ userInitStakedBalances
 ### Setup database & Prisma from backup
 
 Retrieve the current pg_dump file under `https://api-db-dump.s3.eu-central-1.amazonaws.com/canary/api-dump.YYYYMMDD`.
-Database dumps are kept for the previous 7 days, replace YYYYMMDD in the URL above (ie: 20230317)  to download a db dump.
+Database dumps are kept for the previous 7 days, replace YYYYMMDD in the URL above (ie: 20230317) to download a db dump.
 
 Run `docker-compose up -d` to start the database via docker compose.
 
-Retrieve the docker container ID through `docker ps`.
-
-Run `docker exec -i <container-ID> /bin/bash -c "PGPASSWORD=let-me-in psql --username backend database" < /path/on/your/machine/dump`
-with the container-ID from the step before.
+Run `docker exec -i $(docker ps -qf "name=balancer-backend") /bin/bash -c "PGPASSWORD=let-me-in psql --username backend database" < /path/on/your/machine/dump`
 
 The output at the very end saying `ERROR: role "rdsadmin" does not exist` is normal and can be ignored.
 
@@ -90,4 +87,4 @@ To contribute, branch from `v2-canary` (which is our development branch) and ope
 
 ### Database Updates
 
-If you make any changes to the database schema be sure to run `yarn prisma migrate dev --name <change_name>` which will create a new file in `prisma/migrations` that contains all the database changes you've made as an SQL update script. 
+If you make any changes to the database schema be sure to run `yarn prisma migrate dev --name <change_name>` which will create a new file in `prisma/migrations` that contains all the database changes you've made as an SQL update script.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,17 @@ version: '3'
 
 services:
     postgres:
-        image: postgres
+        container_name: balancer-backend
+        image: postgres:14-alpine
         ports:
             - '5431:5432'
         environment:
             POSTGRES_USER: backend
             POSTGRES_PASSWORD: let-me-in
             POSTGRES_DB: database
+        networks:
+            - balancer
+
+networks:
+    balancer:
+        name: balancer

--- a/modules/pool/lib/pool-creator.service.ts
+++ b/modules/pool/lib/pool-creator.service.ts
@@ -272,27 +272,6 @@ export class PoolCreatorService {
         });
     }
 
-    public async reloadPoolTokenIndexes(poolId: string): Promise<void> {
-        const { pool: subgraphPool } = await this.balancerSubgraphService.getPool({ id: poolId });
-
-        if (!subgraphPool) {
-            throw new Error('Pool with id does not exist');
-        }
-
-        const poolTokens = subgraphPool.tokens || [];
-
-        for (let i = 0; i < poolTokens.length; i++) {
-            const token = poolTokens[i];
-
-            await prisma.prismaPoolToken.update({
-                where: { id_chain: { id: token.id, chain: this.chain } },
-                data: {
-                    index: token.index || subgraphPool.tokensList.findIndex((address) => address === token.address),
-                },
-            });
-        }
-    }
-
     private sortSubgraphPools(subgraphPools: BalancerPoolFragment[]) {
         return _.sortBy(subgraphPools, (pool) => {
             const poolType = this.mapSubgraphPoolTypeToPoolType(pool.poolType || '');

--- a/modules/pool/lib/pool-gql-loader.service.ts
+++ b/modules/pool/lib/pool-gql-loader.service.ts
@@ -594,7 +594,7 @@ export class PoolGqlLoaderService {
                     dSq: pool.gyroData?.dSq || '',
                 };
             case 'FX':
-                const data = pool.poolTypeSpecificData as FxData;
+                const data = pool.staticTypeData as FxData;
                 return {
                     __typename: 'GqlPoolFx',
                     ...mappedData,

--- a/modules/pool/lib/pool-gql-loader.service.ts
+++ b/modules/pool/lib/pool-gql-loader.service.ts
@@ -594,7 +594,7 @@ export class PoolGqlLoaderService {
                     dSq: pool.gyroData?.dSq || '',
                 };
             case 'FX':
-                const data = pool.data as FxData;
+                const data = pool.poolTypeSpecificData as FxData;
                 return {
                     __typename: 'GqlPoolFx',
                     ...mappedData,

--- a/modules/pool/lib/pool-gql-loader.service.ts
+++ b/modules/pool/lib/pool-gql-loader.service.ts
@@ -32,6 +32,7 @@ import {
     GqlPoolWithdrawConfig,
     GqlPoolWithdrawOption,
     QueryPoolGetPoolsArgs,
+    GqlPoolFx,
 } from '../../../schema';
 import { isSameAddress } from '@balancer-labs/sdk';
 import _ from 'lodash';
@@ -47,6 +48,7 @@ import { BalancerChainIds, BeethovenChainIds, chainIdToChain, chainToIdMap } fro
 import { GithubContentService } from '../../content/github-content.service';
 import { SanityContentService } from '../../content/sanity-content.service';
 import { FeaturedPool } from '../../content/content-types';
+import { FxData } from '../subgraph-mapper';
 
 export class PoolGqlLoaderService {
     public async getPool(id: string, chain: Chain, userAddress?: string): Promise<GqlPoolUnion> {
@@ -137,6 +139,16 @@ export class PoolGqlLoaderService {
         });
 
         return pools.map((pool) => this.mapPoolToGqlPool(pool)) as GqlPoolGyro[];
+    }
+
+    public async getFxPools(chains: Chain[]): Promise<GqlPoolFx[]> {
+        const pools = await prisma.prismaPool.findMany({
+            where: { type: { in: ['FX'] }, chain: { in: chains } },
+            orderBy: { dynamicData: { totalLiquidity: 'desc' } },
+            include: prismaPoolWithExpandedNesting.include,
+        });
+
+        return pools.map((pool) => this.mapPoolToGqlPool(pool)) as GqlPoolFx[];
     }
 
     public mapToMinimalGqlPool(
@@ -580,6 +592,18 @@ export class PoolGqlLoaderService {
                     w: pool.gyroData?.w || '',
                     z: pool.gyroData?.z || '',
                     dSq: pool.gyroData?.dSq || '',
+                };
+            case 'FX':
+                const data = pool.data as FxData;
+                return {
+                    __typename: 'GqlPoolFx',
+                    ...mappedData,
+                    type: mappedData.type,
+                    alpha: data.alpha || '',
+                    beta: data.beta || '',
+                    delta: data.delta || '',
+                    epsilon: data.epsilon || '',
+                    lambda: data.lambda || '',
                 };
         }
 

--- a/modules/pool/pool-data/element.ts
+++ b/modules/pool/pool-data/element.ts
@@ -1,0 +1,9 @@
+import { BalancerPoolFragment } from '../../subgraphs/balancer-subgraph/generated/balancer-subgraph-types';
+
+export const element = (pool: BalancerPoolFragment) => {
+    return {
+        unitSeconds: pool.unitSeconds || '',
+        principalToken: pool.principalToken || '',
+        baseToken: pool.baseToken || '',
+    };
+};

--- a/modules/pool/pool-data/fx.ts
+++ b/modules/pool/pool-data/fx.ts
@@ -1,0 +1,11 @@
+import { BalancerPoolFragment } from '../../subgraphs/balancer-subgraph/generated/balancer-subgraph-types';
+
+export const fx = (pool: BalancerPoolFragment) => {
+    return {
+        alpha: pool.alpha,
+        beta: pool.beta,
+        delta: pool.delta,
+        epsilon: pool.epsilon,
+        lambda: pool.lambda,
+    };
+};

--- a/modules/pool/pool-data/gyro.ts
+++ b/modules/pool/pool-data/gyro.ts
@@ -1,0 +1,23 @@
+import { BalancerPoolFragment } from '../../subgraphs/balancer-subgraph/generated/balancer-subgraph-types';
+
+export const gyro = (pool: BalancerPoolFragment) => {
+    return {
+        alpha: pool.alpha || '',
+        beta: pool.beta || '',
+        sqrtAlpha: pool.sqrtAlpha || '',
+        sqrtBeta: pool.sqrtBeta || '',
+        root3Alpha: pool.root3Alpha || '',
+        c: pool.c || '',
+        s: pool.s || '',
+        lambda: pool.lambda || '',
+        tauAlphaX: pool.tauAlphaX || '',
+        tauAlphaY: pool.tauAlphaY || '',
+        tauBetaX: pool.tauBetaX || '',
+        tauBetaY: pool.tauBetaY || '',
+        u: pool.u || '',
+        v: pool.v || '',
+        w: pool.w || '',
+        z: pool.z || '',
+        dSq: pool.dSq || '',
+    };
+};

--- a/modules/pool/pool-data/index.ts
+++ b/modules/pool/pool-data/index.ts
@@ -1,0 +1,5 @@
+export * from './element';
+export * from './fx';
+export * from './gyro';
+export * from './linear';
+export * from './stable';

--- a/modules/pool/pool-data/linear.ts
+++ b/modules/pool/pool-data/linear.ts
@@ -1,0 +1,16 @@
+import { BalancerPoolFragment } from '../../subgraphs/balancer-subgraph/generated/balancer-subgraph-types';
+
+export const linear = (pool: BalancerPoolFragment) => {
+    return {
+        mainIndex: pool.mainIndex || 0,
+        wrappedIndex: pool.wrappedIndex || 0,
+    };
+};
+
+export const linearDynamic = (pool: BalancerPoolFragment, blockNumber: number) => {
+    return {
+        upperTarget: pool.upperTarget || '',
+        lowerTarget: pool.lowerTarget || '',
+        blockNumber,
+    };
+};

--- a/modules/pool/pool-data/stable.ts
+++ b/modules/pool/pool-data/stable.ts
@@ -1,0 +1,8 @@
+import { BalancerPoolFragment } from '../../subgraphs/balancer-subgraph/generated/balancer-subgraph-types';
+
+export const stableDynamic = (pool: BalancerPoolFragment, blockNumber: number) => {
+    return {
+        amp: pool.amp || '',
+        blockNumber,
+    };
+};

--- a/modules/pool/pool.gql
+++ b/modules/pool/pool.gql
@@ -24,6 +24,7 @@ extend type Query {
     poolGetSnapshots(id: String!, chain: GqlChain, range: GqlPoolSnapshotDataRange!): [GqlPoolSnapshot!]!
     poolGetLinearPools(chains: [GqlChain!]): [GqlPoolLinear!]!
     poolGetGyroPools(chains: [GqlChain!]): [GqlPoolGyro!]!
+    poolGetFxPools(chains: [GqlChain!]): [GqlPoolFx!]!
 }
 
 extend type Mutation {
@@ -282,6 +283,34 @@ type GqlPoolGyro implements GqlPoolBase {
     userBalance: GqlPoolUserBalance
 }
 
+type GqlPoolFx implements GqlPoolBase {
+    alpha: String!
+    beta: String!
+    delta: String!
+    epsilon: String!
+    lambda: String!
+
+    # Base pool
+    id: ID!
+    chain: GqlChain!
+    type: GqlPoolType!
+    version: Int!
+    name: String!
+    symbol: String!
+    address: Bytes!
+    decimals: Int!
+    owner: Bytes
+    factory: Bytes
+    createTime: Int!
+    investConfig: GqlPoolInvestConfig!
+    withdrawConfig: GqlPoolWithdrawConfig!
+    displayTokens: [GqlPoolTokenDisplay!]!
+    allTokens: [GqlPoolTokenExpanded!]!
+    dynamicData: GqlPoolDynamicData!
+    staking: GqlPoolStaking
+    userBalance: GqlPoolUserBalance
+}
+
 type GqlPoolLiquidityBootstrapping implements GqlPoolBase {
     id: ID!
     chain: GqlChain!
@@ -495,6 +524,7 @@ union GqlPoolUnion =
     | GqlPoolElement
     | GqlPoolLiquidityBootstrapping
     | GqlPoolGyro
+    | GqlPoolFx
 union GqlPoolNestedUnion = GqlPoolLinearNested | GqlPoolComposableStableNested
 
 union GqlPoolTokenUnion = GqlPoolToken | GqlPoolTokenComposableStable | GqlPoolTokenLinear

--- a/modules/pool/pool.gql
+++ b/modules/pool/pool.gql
@@ -54,8 +54,6 @@ extend type Mutation {
     poolBlackListAddPool(poolId: String!): String!
     poolBlackListRemovePool(poolId: String!): String!
     poolDeletePool(poolId: String!): String!
-    poolSyncPriceRateProviders: String!
-    poolSyncProtocolYieldFeeExemptions: String!
     poolInitOnChainDataForAllPools: String!
 }
 

--- a/modules/pool/pool.gql
+++ b/modules/pool/pool.gql
@@ -56,7 +56,6 @@ extend type Mutation {
     poolBlackListAddPool(poolId: String!): String!
     poolBlackListRemovePool(poolId: String!): String!
     poolDeletePool(poolId: String!): String!
-    poolSyncAllPoolTypesVersions: String!
     poolSyncPriceRateProviders: String!
     poolSyncProtocolYieldFeeExemptions: String!
     poolInitOnChainDataForAllPools: String!

--- a/modules/pool/pool.gql
+++ b/modules/pool/pool.gql
@@ -51,7 +51,6 @@ extend type Mutation {
     poolSyncPool(poolId: String!): String!
     poolReloadPoolNestedTokens(poolId: String!): String!
     poolReloadAllTokenNestedPoolIds: String!
-    poolReloadPoolTokenIndexes(poolId: String!): String!
     poolSetPoolsWithPreferredGaugesAsIncentivized: String!
     poolBlackListAddPool(poolId: String!): String!
     poolBlackListRemovePool(poolId: String!): String!

--- a/modules/pool/pool.gql
+++ b/modules/pool/pool.gql
@@ -49,7 +49,6 @@ extend type Mutation {
     poolUpdateLifetimeValuesForAllPools: String!
     poolInitializeSnapshotsForPool(poolId: String!): String!
     poolSyncPool(poolId: String!): String!
-    poolReloadPoolNestedTokens(poolId: String!): String!
     poolReloadAllTokenNestedPoolIds: String!
     poolSetPoolsWithPreferredGaugesAsIncentivized: String!
     poolBlackListAddPool(poolId: String!): String!

--- a/modules/pool/pool.prisma
+++ b/modules/pool/pool.prisma
@@ -18,6 +18,7 @@ model PrismaPool {
     linearData          PrismaPoolLinearData?
     elementData         PrismaPoolElementData?
     gyroData            PrismaPoolGyroData?
+    data                Json @default("{}")
 
     tokens              PrismaPoolToken[]
 

--- a/modules/pool/pool.prisma
+++ b/modules/pool/pool.prisma
@@ -133,8 +133,8 @@ model PrismaPoolDynamicData {
     totalShares             String
     totalSharesNum          Float               @default(0)
     totalLiquidity          Float
-    volume24h               Float
-    fees24h                 Float
+    volume24h               Float               @default(0)
+    fees24h                 Float               @default(0)
     yieldCapture24h         Float               @default(0)
     apr                     Float               @default(0)
     volume48h               Float               @default(0)

--- a/modules/pool/pool.prisma
+++ b/modules/pool/pool.prisma
@@ -65,7 +65,7 @@ model PrismaPoolLinearData {
 
     id                  String
     poolId              String
-    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain])
+    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain], onDelete: Cascade)
     chain               Chain
 
     mainIndex           Int
@@ -78,7 +78,7 @@ model PrismaPoolElementData {
 
     id                  String
     poolId              String
-    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain])
+    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain], onDelete: Cascade)
     chain               Chain
 
     unitSeconds         String
@@ -92,7 +92,7 @@ model PrismaPoolGyroData{
 
     id                  String
     poolId              String
-    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain])
+    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain], onDelete: Cascade)
     chain               Chain
 
     alpha               String
@@ -120,7 +120,7 @@ model PrismaPoolDynamicData {
 
     id                      String
     poolId                  String
-    pool                    PrismaPool          @relation(fields:[poolId, chain], references: [id, chain])
+    pool                    PrismaPool          @relation(fields:[poolId, chain], references: [id, chain], onDelete: Cascade)
     chain                   Chain
     blockNumber             Int
     updatedAt               DateTime            @updatedAt
@@ -174,7 +174,7 @@ model PrismaPoolStableDynamicData {
 
     id                  String
     poolId              String
-    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain])
+    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain], onDelete: Cascade)
     chain               Chain
     blockNumber         Int
     updatedAt           DateTime            @updatedAt
@@ -188,7 +188,7 @@ model PrismaPoolLinearDynamicData {
 
     id                  String
     poolId              String
-    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain])
+    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain], onDelete: Cascade)
     chain               Chain
     blockNumber         Int
     updatedAt           DateTime            @updatedAt
@@ -202,7 +202,7 @@ model PrismaPoolToken {
 
     id                          String
     poolId                      String
-    pool                        PrismaPool          @relation(fields:[poolId, chain], references: [id, chain])
+    pool                        PrismaPool          @relation(fields:[poolId, chain], references: [id, chain], onDelete: Cascade)
     chain                       Chain
 
     address                     String
@@ -224,7 +224,7 @@ model PrismaPoolTokenDynamicData {
 
     id                  String
     poolTokenId         String
-    poolToken           PrismaPoolToken     @relation(fields:[poolTokenId, chain], references: [id, chain])
+    poolToken           PrismaPoolToken     @relation(fields:[poolTokenId, chain], references: [id, chain], onDelete: Cascade)
     chain               Chain
     blockNumber         Int
     updatedAt           DateTime            @updatedAt
@@ -241,7 +241,7 @@ model PrismaPoolSwap {
 
     id                  String
     poolId              String
-    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain])
+    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain], onDelete: Cascade)
     chain               Chain
 
     userAddress         String
@@ -284,7 +284,7 @@ model PrismaPoolAprItem {
 
     id                  String
     poolId              String
-    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain])
+    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain], onDelete: Cascade)
     chain               Chain
     title               String
     apr                 Float
@@ -301,7 +301,7 @@ model PrismaPoolAprRange {
     id                  String
     chain               Chain
     aprItemId           String
-    aprItem             PrismaPoolAprItem   @relation(fields:[aprItemId, chain], references: [id, chain])
+    aprItem             PrismaPoolAprItem   @relation(fields:[aprItemId, chain], references: [id, chain], onDelete: Cascade)
     min                 Float
     max                 Float
 }
@@ -355,11 +355,11 @@ model PrismaPoolExpandedTokens {
     tokenAddress        String
     token               PrismaToken         @relation(fields:[tokenAddress, chain], references: [address, chain])
     poolId              String
-    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain])
+    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain], onDelete: Cascade)
     chain               Chain
 
     nestedPoolId        String?
-    nestedPool          PrismaPool?         @relation(name: "NestedPoolForAllToken", fields:[nestedPoolId, chain], references: [id, chain])
+    nestedPool          PrismaPool?         @relation(name: "NestedPoolForAllToken", fields:[nestedPoolId, chain], references: [id, chain], onDelete: Cascade)
 }
 
 
@@ -381,7 +381,7 @@ model PrismaPoolFilterMap {
     filterId            String
     filter              PrismaPoolFilter    @relation(fields:[filterId, chain], references: [id, chain])
     poolId              String
-    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain])
+    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain], onDelete: Cascade)
 }
 
 model PrismaPoolStaking {
@@ -389,7 +389,7 @@ model PrismaPoolStaking {
 
     id                  String
     poolId              String
-    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain])
+    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain], onDelete: Cascade)
     chain               Chain
     type                PrismaPoolStakingType
     address             String
@@ -439,7 +439,7 @@ model PrismaPoolStakingGauge {
 
     id                  String
     stakingId           String
-    staking             PrismaPoolStaking   @relation(fields:[stakingId, chain], references: [id, chain])
+    staking             PrismaPoolStaking   @relation(fields:[stakingId, chain], references: [id, chain], onDelete: Cascade)
     chain               Chain
 
     gaugeAddress        String
@@ -463,7 +463,7 @@ model PrismaPoolStakingGaugeReward{
 
     id                  String
     gaugeId             String
-    gauge               PrismaPoolStakingGauge @relation(fields:[gaugeId, chain], references: [id, chain])
+    gauge               PrismaPoolStakingGauge @relation(fields:[gaugeId, chain], references: [id, chain], onDelete: Cascade)
     chain               Chain
 
     tokenAddress        String
@@ -510,7 +510,7 @@ model PrismaPoolSnapshot {
 
     id                  String
     poolId              String
-    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain])
+    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain], onDelete: Cascade)
     chain               Chain
     timestamp           Int
 

--- a/modules/pool/pool.prisma
+++ b/modules/pool/pool.prisma
@@ -18,7 +18,7 @@ model PrismaPool {
     linearData          PrismaPoolLinearData?
     elementData         PrismaPoolElementData?
     gyroData            PrismaPoolGyroData?
-    poolTypeSpecificData Json @default("{}")
+    staticTypeData      Json @default("{}")
 
     tokens              PrismaPoolToken[]
 

--- a/modules/pool/pool.prisma
+++ b/modules/pool/pool.prisma
@@ -18,7 +18,7 @@ model PrismaPool {
     linearData          PrismaPoolLinearData?
     elementData         PrismaPoolElementData?
     gyroData            PrismaPoolGyroData?
-    data                Json @default("{}")
+    poolTypeSpecificData Json @default("{}")
 
     tokens              PrismaPoolToken[]
 

--- a/modules/pool/pool.resolvers.ts
+++ b/modules/pool/pool.resolvers.ts
@@ -314,13 +314,6 @@ const balancerResolvers: Resolvers = {
 
             return 'success';
         },
-        poolSyncAllPoolTypesVersions: async (parent, {}, context) => {
-            isAdminRoute(context);
-
-            await poolService.syncPoolTypeAndVersionForAllPools();
-
-            return 'success';
-        },
         poolSyncPriceRateProviders: async (parent, {}, context) => {
             isAdminRoute(context);
 

--- a/modules/pool/pool.resolvers.ts
+++ b/modules/pool/pool.resolvers.ts
@@ -279,13 +279,6 @@ const balancerResolvers: Resolvers = {
 
             return 'success';
         },
-        poolReloadPoolTokenIndexes: async (parent, { poolId }, context) => {
-            isAdminRoute(context);
-
-            await poolService.reloadPoolTokenIndexes(poolId);
-
-            return 'success';
-        },
         poolSetPoolsWithPreferredGaugesAsIncentivized: async (parent, {}, context) => {
             isAdminRoute(context);
 

--- a/modules/pool/pool.resolvers.ts
+++ b/modules/pool/pool.resolvers.ts
@@ -94,6 +94,16 @@ const balancerResolvers: Resolvers = {
         poolGetGyroPools: async () => {
             return poolService.getGqlGyroPools();
         },
+
+        poolGetFxPools: async (parent, { chains }) => {
+            const currentChain = headerChain();
+            if (!chains && currentChain) {
+                chains = [currentChain];
+            } else if (!chains) {
+                throw new Error('poolGetLinearPools error: Provide "chains" param');
+            }
+            return poolService.getGqlFxPools(chains);
+        },
     },
     Mutation: {
         poolSyncAllPoolsFromSubgraph: async (parent, {}, context) => {

--- a/modules/pool/pool.resolvers.ts
+++ b/modules/pool/pool.resolvers.ts
@@ -300,20 +300,6 @@ const balancerResolvers: Resolvers = {
 
             return 'success';
         },
-        poolSyncPriceRateProviders: async (parent, {}, context) => {
-            isAdminRoute(context);
-
-            await poolService.syncPriceRateProvidersForAllPools();
-
-            return 'success';
-        },
-        poolSyncProtocolYieldFeeExemptions: async (parent, {}, context) => {
-            isAdminRoute(context);
-
-            await poolService.syncProtocolYieldFeeExemptionsForAllPools();
-
-            return 'success';
-        },
     },
 };
 

--- a/modules/pool/pool.resolvers.ts
+++ b/modules/pool/pool.resolvers.ts
@@ -265,13 +265,6 @@ const balancerResolvers: Resolvers = {
 
             return 'success';
         },
-        poolReloadPoolNestedTokens: async (parent, { poolId }, context) => {
-            isAdminRoute(context);
-
-            await poolService.reloadPoolNestedTokens(poolId);
-
-            return 'success';
-        },
         poolReloadAllTokenNestedPoolIds: async (parent, {}, context) => {
             isAdminRoute(context);
 

--- a/modules/pool/pool.service.ts
+++ b/modules/pool/pool.service.ts
@@ -379,12 +379,7 @@ export class PoolService {
             where: { chain: this.chain, poolId: poolId },
         });
 
-        const poolTokenIds = poolTokens.map((poolToken) => poolToken.id);
         const poolTokenAddresses = poolTokens.map((poolToken) => poolToken.address);
-
-        await prisma.prismaPoolSnapshot.deleteMany({
-            where: { chain: this.chain, poolId: poolId },
-        });
 
         await prisma.prismaTokenType.deleteMany({
             where: { chain: this.chain, tokenAddress: pool.address },
@@ -394,48 +389,8 @@ export class PoolService {
             where: { chain: this.chain, poolId: poolId },
         });
 
-        await prisma.prismaPoolTokenDynamicData.deleteMany({
-            where: { chain: this.chain, poolTokenId: { in: poolTokenIds } },
-        });
-
         await prisma.prismaTokenDynamicData.deleteMany({
             where: { chain: this.chain, tokenAddress: { in: poolTokenAddresses } },
-        });
-
-        await prisma.prismaPoolToken.deleteMany({
-            where: { chain: this.chain, poolId: poolId },
-        });
-
-        await prisma.prismaPoolDynamicData.deleteMany({
-            where: { chain: this.chain, poolId: poolId },
-        });
-
-        await prisma.prismaPoolToken.deleteMany({
-            where: { chain: this.chain, poolId: poolId },
-        });
-
-        await prisma.prismaPoolLinearData.deleteMany({
-            where: { chain: this.chain, poolId: poolId },
-        });
-
-        await prisma.prismaPoolGyroData.deleteMany({
-            where: { chain: this.chain, poolId: poolId },
-        });
-
-        await prisma.prismaPoolExpandedTokens.deleteMany({
-            where: { chain: this.chain, poolId: poolId },
-        });
-
-        await prisma.prismaPoolLinearDynamicData.deleteMany({
-            where: { chain: this.chain, poolId: poolId },
-        });
-
-        await prisma.prismaPoolAprItem.deleteMany({
-            where: { chain: this.chain, poolId: poolId },
-        });
-
-        await prisma.prismaPoolSwap.deleteMany({
-            where: { chain: this.chain, poolId: poolId },
         });
 
         const poolStaking = await prisma.prismaPoolStaking.findMany({

--- a/modules/pool/pool.service.ts
+++ b/modules/pool/pool.service.ts
@@ -333,10 +333,6 @@ export class PoolService {
         await this.poolSnapshotService.createPoolSnapshotsForPoolsMissingSubgraphData(poolId);
     }
 
-    public async reloadPoolNestedTokens(poolId: string) {
-        await this.poolCreatorService.reloadPoolNestedTokens(poolId);
-    }
-
     public async reloadAllTokenNestedPoolIds() {
         await this.poolCreatorService.reloadAllTokenNestedPoolIds();
     }

--- a/modules/pool/pool.service.ts
+++ b/modules/pool/pool.service.ts
@@ -349,10 +349,6 @@ export class PoolService {
         await this.poolSyncService.setPoolsWithPreferredGaugesAsIncentivized();
     }
 
-    public async syncPoolTypeAndVersionForAllPools() {
-        await this.poolCreatorService.updatePoolTypesAndVersionForAllPools();
-    }
-
     public async syncProtocolYieldFeeExemptionsForAllPools() {
         const subgraphPools = await this.balancerSubgraphService.getAllPools({}, false);
         for (const subgraphPool of subgraphPools) {

--- a/modules/pool/pool.service.ts
+++ b/modules/pool/pool.service.ts
@@ -8,6 +8,7 @@ import {
     GqlPoolBatchSwap,
     GqlPoolFeaturedPool,
     GqlPoolFeaturedPoolGroup,
+    GqlPoolFx,
     GqlPoolGyro,
     GqlPoolJoinExit,
     GqlPoolLinear,
@@ -85,6 +86,10 @@ export class PoolService {
 
     public async getGqlGyroPools(): Promise<GqlPoolGyro[]> {
         return this.poolGqlLoaderService.getGyroPools();
+    }
+
+    public async getGqlFxPools(chains: Chain[]): Promise<GqlPoolFx[]> {
+        return this.poolGqlLoaderService.getFxPools(chains);
     }
 
     public async getPoolsCount(args: QueryPoolGetPoolsArgs): Promise<number> {

--- a/modules/pool/pool.service.ts
+++ b/modules/pool/pool.service.ts
@@ -341,10 +341,6 @@ export class PoolService {
         await this.poolCreatorService.reloadAllTokenNestedPoolIds();
     }
 
-    public async reloadPoolTokenIndexes(poolId: string) {
-        await this.poolCreatorService.reloadPoolTokenIndexes(poolId);
-    }
-
     public async setPoolsWithPreferredGaugesAsIncentivized() {
         await this.poolSyncService.setPoolsWithPreferredGaugesAsIncentivized();
     }

--- a/modules/pool/subgraph-mapper.test.ts
+++ b/modules/pool/subgraph-mapper.test.ts
@@ -1,0 +1,91 @@
+import { subgraphToPrisma } from './subgraph-mapper';
+import { poolFactory, poolTokenFactory } from '../../test/factories';
+
+describe('subgraphToPrisma', () => {
+    const weightedPool = poolFactory.build({
+        poolType: 'Weighted',
+    });
+
+    const stablePool = poolFactory.build({
+        poolType: 'ComposableStable',
+        amp: '0.1',
+    });
+
+    const linearPool = poolFactory.build({
+        poolType: 'Linear',
+        wrappedIndex: 1,
+        upperTarget: '1',
+    });
+
+    const elementPool = poolFactory.build({
+        poolType: 'Element',
+        principalToken: '0x123',
+    });
+
+    const gyroPool = poolFactory.build({
+        poolType: 'GyroE',
+        alpha: '0.5',
+        tauAlphaX: '0.5',
+    });
+
+    const fxPool = poolFactory.build({
+        poolType: 'FX',
+        alpha: '0.5',
+    });
+
+    it('should return correct object for weighted pool', () => {
+        const result = subgraphToPrisma(weightedPool, 'MAINNET', 1, []);
+        expect(result.data.type).toBe('WEIGHTED');
+    });
+
+    it('should return correct object for stable pool', () => {
+        const result = subgraphToPrisma(stablePool, 'MAINNET', 1, []);
+        expect(result.data.type).toBe('COMPOSABLE_STABLE');
+        expect(result.data.stableDynamicData?.create.amp).toBe(stablePool.amp);
+    });
+
+    it('should return correct object for linear pool', () => {
+        const result = subgraphToPrisma(linearPool, 'MAINNET', 1, []);
+        expect(result.data.type).toBe('LINEAR');
+        expect(result.data.linearDynamicData?.create.upperTarget).toBe(linearPool.upperTarget);
+        expect(result.data.linearData?.create.wrappedIndex).toBe(linearPool.wrappedIndex);
+    });
+
+    it('should return correct object for element pool', () => {
+        const result = subgraphToPrisma(elementPool, 'MAINNET', 1, []);
+        expect(result.data.type).toBe('ELEMENT');
+        expect(result.data.elementData?.create.principalToken).toBe(elementPool.principalToken);
+    });
+
+    it('should return correct object for gyro pool', () => {
+        const result = subgraphToPrisma(gyroPool, 'MAINNET', 1, []);
+        expect(result.data.type).toBe('GYROE');
+        expect(result.data.gyroData?.create.alpha).toBe(gyroPool.alpha);
+        expect(result.data.gyroData?.create.tauAlphaX).toBe(gyroPool.tauAlphaX);
+    });
+
+    it('should return correct object for fx pool', () => {
+        const result = subgraphToPrisma(fxPool, 'MAINNET', 1, []);
+        expect(result.data.type).toBe('FX');
+        expect(result.data.data['alpha']).toBe(gyroPool.alpha);
+    });
+
+    describe('nested pools', () => {
+        const nestedPools = [linearPool];
+        const poolWithNestedPools = poolFactory.build({
+            poolType: 'ComposableStable',
+            tokens: [
+                poolTokenFactory.build({
+                    address: linearPool.address,
+                }),
+                poolTokenFactory.build({}),
+            ],
+        });
+
+        it('should recognise nested pools', () => {
+            const result = subgraphToPrisma(poolWithNestedPools, 'MAINNET', 1, nestedPools);
+            expect(result.data.type).toBe('COMPOSABLE_STABLE');
+            expect(result.data.tokens.createMany.data[0].nestedPoolId).toBe(linearPool.id);
+        });
+    });
+});

--- a/modules/pool/subgraph-mapper.test.ts
+++ b/modules/pool/subgraph-mapper.test.ts
@@ -79,7 +79,7 @@ describe('subgraphToPrismaCreate', () => {
     it('should return correct object for fx pool', () => {
         const result = subgraphToPrismaCreate(fxPool, 'MAINNET', 1, []);
         expect(result.data.type).toBe('FX');
-        expect(result.data.data['alpha']).toBe(gyroPool.alpha);
+        expect(result.data.poolTypeSpecificData['alpha']).toBe(gyroPool.alpha);
     });
 
     describe('nested pools', () => {

--- a/modules/pool/subgraph-mapper.test.ts
+++ b/modules/pool/subgraph-mapper.test.ts
@@ -1,13 +1,18 @@
-import { subgraphToPrisma } from './subgraph-mapper';
+import { subgraphToPrismaCreate } from './subgraph-mapper';
 import { poolFactory, poolTokenFactory } from '../../test/factories';
 
-describe('subgraphToPrisma', () => {
+describe('subgraphToPrismaCreate', () => {
     const weightedPool = poolFactory.build({
         poolType: 'Weighted',
     });
 
     const stablePool = poolFactory.build({
         poolType: 'ComposableStable',
+        amp: '0.1',
+    });
+
+    const oldStablePool = poolFactory.build({
+        poolType: 'StablePhantom',
         amp: '0.1',
     });
 
@@ -34,38 +39,45 @@ describe('subgraphToPrisma', () => {
     });
 
     it('should return correct object for weighted pool', () => {
-        const result = subgraphToPrisma(weightedPool, 'MAINNET', 1, []);
+        const result = subgraphToPrismaCreate(weightedPool, 'MAINNET', 1, []);
         expect(result.data.type).toBe('WEIGHTED');
     });
 
     it('should return correct object for stable pool', () => {
-        const result = subgraphToPrisma(stablePool, 'MAINNET', 1, []);
+        const result = subgraphToPrismaCreate(stablePool, 'MAINNET', 1, []);
         expect(result.data.type).toBe('COMPOSABLE_STABLE');
         expect(result.data.stableDynamicData?.create.amp).toBe(stablePool.amp);
     });
 
+    it('should return correct object for old stable pool', () => {
+        const result = subgraphToPrismaCreate(oldStablePool, 'MAINNET', 1, []);
+        expect(result.data.type).toBe('COMPOSABLE_STABLE');
+        expect(result.data.version).toBe(0);
+        expect(result.data.stableDynamicData?.create.amp).toBe(oldStablePool.amp);
+    });
+
     it('should return correct object for linear pool', () => {
-        const result = subgraphToPrisma(linearPool, 'MAINNET', 1, []);
+        const result = subgraphToPrismaCreate(linearPool, 'MAINNET', 1, []);
         expect(result.data.type).toBe('LINEAR');
         expect(result.data.linearDynamicData?.create.upperTarget).toBe(linearPool.upperTarget);
         expect(result.data.linearData?.create.wrappedIndex).toBe(linearPool.wrappedIndex);
     });
 
     it('should return correct object for element pool', () => {
-        const result = subgraphToPrisma(elementPool, 'MAINNET', 1, []);
+        const result = subgraphToPrismaCreate(elementPool, 'MAINNET', 1, []);
         expect(result.data.type).toBe('ELEMENT');
         expect(result.data.elementData?.create.principalToken).toBe(elementPool.principalToken);
     });
 
     it('should return correct object for gyro pool', () => {
-        const result = subgraphToPrisma(gyroPool, 'MAINNET', 1, []);
+        const result = subgraphToPrismaCreate(gyroPool, 'MAINNET', 1, []);
         expect(result.data.type).toBe('GYROE');
         expect(result.data.gyroData?.create.alpha).toBe(gyroPool.alpha);
         expect(result.data.gyroData?.create.tauAlphaX).toBe(gyroPool.tauAlphaX);
     });
 
     it('should return correct object for fx pool', () => {
-        const result = subgraphToPrisma(fxPool, 'MAINNET', 1, []);
+        const result = subgraphToPrismaCreate(fxPool, 'MAINNET', 1, []);
         expect(result.data.type).toBe('FX');
         expect(result.data.data['alpha']).toBe(gyroPool.alpha);
     });
@@ -83,7 +95,7 @@ describe('subgraphToPrisma', () => {
         });
 
         it('should recognise nested pools', () => {
-            const result = subgraphToPrisma(poolWithNestedPools, 'MAINNET', 1, nestedPools);
+            const result = subgraphToPrismaCreate(poolWithNestedPools, 'MAINNET', 1, nestedPools);
             expect(result.data.type).toBe('COMPOSABLE_STABLE');
             expect(result.data.tokens.createMany.data[0].nestedPoolId).toBe(linearPool.id);
         });

--- a/modules/pool/subgraph-mapper.ts
+++ b/modules/pool/subgraph-mapper.ts
@@ -1,0 +1,221 @@
+import { Chain, PrismaPoolType } from '@prisma/client';
+import { BalancerPoolFragment } from '../subgraphs/balancer-subgraph/generated/balancer-subgraph-types';
+import { AddressZero } from '@ethersproject/constants';
+import * as dataMappers from './pool-data';
+
+export const subgraphToPrisma = (
+    pool: BalancerPoolFragment,
+    chain: Chain,
+    blockNumber: number,
+    nestedPools: { id: string; address: string }[],
+) => {
+    const dbData = subgraphMapper(pool, chain, blockNumber, nestedPools);
+
+    const prismaPoolRecordWithAssociations = {
+        data: {
+            ...dbData.base,
+            data: dbData.data, // DISCUSS: simplify DB schema by migrating from individual tables to a JSON column with types enforced on read. And same with dynamic data.
+            tokens: {
+                createMany: {
+                    data: dbData.tokens,
+                },
+            },
+            dynamicData: {
+                create: {
+                    id: dbData.base.id,
+                    ...dbData.dynamicData,
+                },
+            },
+            linearData:
+                dbData.base.type === 'LINEAR'
+                    ? {
+                          create: {
+                              id: dbData.base.id,
+                              ...(dbData.data as ReturnType<typeof dataMapper['LINEAR']>),
+                          },
+                      }
+                    : undefined,
+            elementData:
+                dbData.base.type === 'ELEMENT'
+                    ? {
+                          create: {
+                              id: dbData.base.id,
+                              ...(dbData.data as ReturnType<typeof dataMapper['ELEMENT']>),
+                          },
+                      }
+                    : undefined,
+            gyroData: ['GYRO', 'GYRO3', 'GYROE'].includes(dbData.base.type)
+                ? {
+                      create: {
+                          id: dbData.base.id,
+                          ...(dbData.data as ReturnType<typeof dataMapper['GYRO']>),
+                      },
+                  }
+                : undefined,
+            linearDynamicData:
+                dbData.base.type === 'LINEAR'
+                    ? {
+                          create: {
+                              id: dbData.base.id,
+                              ...(dbData.dynamicTypeData as ReturnType<typeof dynamicMapper['LINEAR']>),
+                          },
+                      }
+                    : undefined,
+            stableDynamicData: ['STABLE', 'COMPOSABLE_STABLE', 'META_STABLE'].includes(dbData.base.type)
+                ? {
+                      create: {
+                          id: dbData.base.id,
+                          ...(dbData.dynamicTypeData as ReturnType<typeof dynamicMapper['STABLE']>),
+                      },
+                  }
+                : undefined,
+        },
+    };
+
+    return prismaPoolRecordWithAssociations;
+};
+
+const subgraphMapper = (
+    pool: BalancerPoolFragment,
+    chain: Chain,
+    blockNumber: number,
+    nestedPools: { id: string; address: string }[],
+) => {
+    const type = mapSubgraphPoolTypeToPoolType(pool.poolType!);
+    const version = mapPoolTypeVersion(type, pool.poolTypeVersion!);
+
+    const base = {
+        id: pool.id,
+        chain: chain,
+        createTime: pool.createTime,
+        address: pool.address,
+        symbol: pool.symbol || '',
+        name: pool.name || '',
+        decimals: 18,
+        type: type,
+        version: version,
+        owner: pool.owner || AddressZero,
+        factory: pool.factory,
+    };
+
+    const dynamicData = {
+        blockNumber,
+        swapFee: pool.swapFee,
+        swapEnabled: pool.swapEnabled,
+        totalShares: pool.totalShares,
+        totalSharesNum: parseFloat(pool.totalShares),
+        totalLiquidity: Math.max(parseFloat(pool.totalLiquidity), 0),
+    };
+
+    const data: ReturnType<typeof dataMapper[keyof typeof dataMapper]> | {} = Object.keys(dataMapper).includes(type)
+        ? dataMapper[type as keyof typeof dataMapper](pool)
+        : {};
+
+    const dynamicTypeData = Object.keys(dynamicMapper).includes(type)
+        ? dynamicMapper[type as keyof typeof dynamicMapper](pool, blockNumber)
+        : {};
+
+    const tokens =
+        pool.tokens?.map((token) => {
+            const nestedPool = nestedPools.find((nestedPool) => {
+                return nestedPool.address === token.address;
+            });
+
+            let priceRateProvider;
+            if (pool.priceRateProviders) {
+                const data = pool.priceRateProviders.find((provider) => provider.token.address === token.address);
+                priceRateProvider = data?.address;
+            }
+
+            return {
+                id: token.id,
+                address: token.address,
+                priceRateProvider,
+                exemptFromProtocolYieldFee: token.isExemptFromYieldProtocolFee
+                    ? token.isExemptFromYieldProtocolFee
+                    : false,
+                nestedPoolId: nestedPool?.id,
+                index: token.index || pool.tokensList.findIndex((address) => address === token.address),
+            };
+        }) ?? [];
+
+    return {
+        base,
+        dynamicData,
+        tokens,
+        data,
+        dynamicTypeData,
+    };
+};
+
+const mapSubgraphPoolTypeToPoolType = (poolType: string): PrismaPoolType => {
+    switch (poolType) {
+        case 'Weighted':
+            return 'WEIGHTED';
+        case 'LiquidityBootstrapping':
+            return 'LIQUIDITY_BOOTSTRAPPING';
+        case 'Stable':
+            return 'STABLE';
+        case 'MetaStable':
+            return 'META_STABLE';
+        // for the old phantom stable pool, we add it to the DB as type COMPOSABLE_STABLE with version 0
+        case 'StablePhantom':
+            return 'COMPOSABLE_STABLE';
+        case 'ComposableStable':
+            return 'COMPOSABLE_STABLE';
+        case 'Linear':
+            return 'LINEAR';
+        case 'Element':
+            return 'ELEMENT';
+        case 'Investment':
+            return 'INVESTMENT';
+        case 'Gyro2':
+            return 'GYRO';
+        case 'Gyro3':
+            return 'GYRO3';
+        case 'GyroE':
+            return 'GYROE';
+        case 'FX':
+            return 'FX';
+    }
+
+    // balancer still uses AaveLinear, etc, so we account for that here
+    if (poolType.includes('Linear')) {
+        return 'LINEAR';
+    }
+
+    return 'UNKNOWN';
+};
+
+const mapPoolTypeVersion = (poolType: string, poolTypeVersion: number): number => {
+    // for the old phantom stable pool, we add it to the DB as type COMPOSABLE_STABLE with version 0
+    let version = poolTypeVersion ? poolTypeVersion : 1;
+    if (poolType === 'StablePhantom') {
+        version = 0;
+    }
+
+    return version;
+};
+
+const dataMapper = {
+    ELEMENT: dataMappers.element,
+    FX: dataMappers.fx,
+    GYRO: dataMappers.gyro,
+    GYRO3: dataMappers.gyro,
+    GYROE: dataMappers.gyro,
+    LINEAR: dataMappers.linear,
+};
+
+const dynamicMapper = {
+    STABLE: dataMappers.stableDynamic,
+    COMPOSABLE_STABLE: dataMappers.stableDynamic,
+    META_STABLE: dataMappers.stableDynamic,
+    LINEAR: dataMappers.linearDynamic,
+};
+
+export type FxData = ReturnType<typeof dataMappers['fx']>;
+export type GyroData = ReturnType<typeof dataMappers['gyro']>;
+export type LinearData = ReturnType<typeof dataMappers['linear']>;
+export type ElementData = ReturnType<typeof dataMappers['element']>;
+export type StableDynamicData = ReturnType<typeof dataMappers['stableDynamic']>;
+export type LinearDynamicData = ReturnType<typeof dataMappers['linearDynamic']>;

--- a/modules/pool/subgraph-mapper.ts
+++ b/modules/pool/subgraph-mapper.ts
@@ -87,6 +87,19 @@ export const subgraphToPrismaUpdate = (
     const prismaPoolRecordWithDataAssociations = {
         ...baseWithoutId,
         data: dbData.data, // DISCUSS: simplify DB schema by migrating from individual tables to a JSON column with types enforced on read. And same with dynamic data.
+        tokens: {
+            update: dbData.tokens.map((token) => ({
+                where: {
+                    id_chain: {
+                        id: token.id,
+                        chain: chain,
+                    },
+                },
+                data: {
+                    ...token,
+                },
+            })),
+        },
         linearData:
             dbData.base.type === 'LINEAR'
                 ? {

--- a/modules/pool/subgraph-mapper.ts
+++ b/modules/pool/subgraph-mapper.ts
@@ -14,7 +14,7 @@ export const subgraphToPrismaCreate = (
     const prismaPoolRecordWithAssociations = {
         data: {
             ...dbData.base,
-            poolTypeSpecificData: dbData.staticTypeData,
+            staticTypeData: dbData.staticTypeData,
             tokens: {
                 createMany: {
                     data: dbData.tokens,
@@ -86,7 +86,7 @@ export const subgraphToPrismaUpdate = (
 
     const prismaPoolRecordWithDataAssociations = {
         ...baseWithoutId,
-        poolTypeSpecificData: dbData.staticTypeData,
+        staticTypeData: dbData.staticTypeData,
         tokens: {
             update: dbData.tokens.map((token) => ({
                 where: {

--- a/modules/pool/subgraph-mapper.ts
+++ b/modules/pool/subgraph-mapper.ts
@@ -14,7 +14,7 @@ export const subgraphToPrismaCreate = (
     const prismaPoolRecordWithAssociations = {
         data: {
             ...dbData.base,
-            data: dbData.data, // DISCUSS: simplify DB schema by migrating from individual tables to a JSON column with types enforced on read. And same with dynamic data.
+            poolTypeSpecificData: dbData.data,
             tokens: {
                 createMany: {
                     data: dbData.tokens,
@@ -86,7 +86,7 @@ export const subgraphToPrismaUpdate = (
 
     const prismaPoolRecordWithDataAssociations = {
         ...baseWithoutId,
-        data: dbData.data, // DISCUSS: simplify DB schema by migrating from individual tables to a JSON column with types enforced on read. And same with dynamic data.
+        poolTypeSpecificData: dbData.data,
         tokens: {
             update: dbData.tokens.map((token) => ({
                 where: {

--- a/modules/pool/subgraph-mapper.ts
+++ b/modules/pool/subgraph-mapper.ts
@@ -150,7 +150,7 @@ const subgraphMapper = (
     nestedPools: { id: string; address: string }[],
 ) => {
     const type = mapSubgraphPoolTypeToPoolType(pool.poolType!);
-    const version = mapPoolTypeVersion(type, pool.poolTypeVersion!);
+    const version = mapPoolTypeVersion(pool.poolType!, pool.poolTypeVersion!);
 
     const base = {
         id: pool.id,

--- a/modules/pool/subgraph-mapper.ts
+++ b/modules/pool/subgraph-mapper.ts
@@ -1,7 +1,7 @@
 import { Chain, PrismaPoolType } from '@prisma/client';
 import { BalancerPoolFragment } from '../subgraphs/balancer-subgraph/generated/balancer-subgraph-types';
 import { AddressZero } from '@ethersproject/constants';
-import * as dataMappers from './pool-data';
+import { fx, gyro, linear, element, stableDynamic, linearDynamic } from './pool-data';
 
 export const subgraphToPrismaCreate = (
     pool: BalancerPoolFragment,
@@ -266,24 +266,24 @@ const mapPoolTypeVersion = (poolType: string, poolTypeVersion: number): number =
 };
 
 const dataMapper = {
-    ELEMENT: dataMappers.element,
-    FX: dataMappers.fx,
-    GYRO: dataMappers.gyro,
-    GYRO3: dataMappers.gyro,
-    GYROE: dataMappers.gyro,
-    LINEAR: dataMappers.linear,
+    ELEMENT: element,
+    FX: fx,
+    GYRO: gyro,
+    GYRO3: gyro,
+    GYROE: gyro,
+    LINEAR: linear,
 };
 
 const dynamicMapper = {
-    STABLE: dataMappers.stableDynamic,
-    COMPOSABLE_STABLE: dataMappers.stableDynamic,
-    META_STABLE: dataMappers.stableDynamic,
-    LINEAR: dataMappers.linearDynamic,
+    STABLE: stableDynamic,
+    COMPOSABLE_STABLE: stableDynamic,
+    META_STABLE: stableDynamic,
+    LINEAR: linearDynamic,
 };
 
-export type FxData = ReturnType<typeof dataMappers['fx']>;
-export type GyroData = ReturnType<typeof dataMappers['gyro']>;
-export type LinearData = ReturnType<typeof dataMappers['linear']>;
-export type ElementData = ReturnType<typeof dataMappers['element']>;
-export type StableDynamicData = ReturnType<typeof dataMappers['stableDynamic']>;
-export type LinearDynamicData = ReturnType<typeof dataMappers['linearDynamic']>;
+export type FxData = ReturnType<typeof fx>;
+export type GyroData = ReturnType<typeof gyro>;
+export type LinearData = ReturnType<typeof linear>;
+export type ElementData = ReturnType<typeof element>;
+export type StableDynamicData = ReturnType<typeof stableDynamic>;
+export type LinearDynamicData = ReturnType<typeof linearDynamic>;

--- a/modules/sor/sorV2/sorV2.service.ts
+++ b/modules/sor/sorV2/sorV2.service.ts
@@ -430,7 +430,7 @@ export class SorV2Service implements SwapService {
                 name: 'n/a',
             };
             if (['FX'].includes(rawPool.poolType)) {
-                const data = prismaPool.data as FxData;
+                const data = prismaPool.poolTypeSpecificData as FxData;
                 rawPool = {
                     ...rawPool,
                     ...data,

--- a/modules/sor/sorV2/sorV2.service.ts
+++ b/modules/sor/sorV2/sorV2.service.ts
@@ -430,7 +430,7 @@ export class SorV2Service implements SwapService {
                 name: 'n/a',
             };
             if (['FX'].includes(rawPool.poolType)) {
-                const data = prismaPool.poolTypeSpecificData as FxData;
+                const data = prismaPool.staticTypeData as FxData;
                 rawPool = {
                     ...rawPool,
                     ...data,

--- a/modules/subgraphs/balancer-subgraph/balancer-subgraph-queries.graphql
+++ b/modules/subgraphs/balancer-subgraph/balancer-subgraph-queries.graphql
@@ -198,6 +198,9 @@ fragment BalancerPool on Pool {
     w
     z
     dSq
+    delta
+    epsilon
+
     priceRateProviders {
         address
         token {

--- a/modules/user/user.prisma
+++ b/modules/user/user.prisma
@@ -26,7 +26,7 @@ model PrismaUserWalletBalance {
     user                    PrismaUser          @relation(fields:[userAddress], references: [address])
 
     poolId                  String?
-    pool                    PrismaPool?         @relation(fields:[poolId, chain], references: [id, chain])
+    pool                    PrismaPool?         @relation(fields:[poolId, chain], references: [id, chain], onDelete: Cascade)
 
     tokenAddress            String
     token                   PrismaToken         @relation(fields:[tokenAddress, chain], references: [address, chain])
@@ -46,13 +46,13 @@ model PrismaUserStakedBalance {
     user                    PrismaUser          @relation(fields:[userAddress], references: [address])
 
     poolId                  String?
-    pool                    PrismaPool?          @relation(fields:[poolId, chain], references: [id, chain])
+    pool                    PrismaPool?          @relation(fields:[poolId, chain], references: [id, chain], onDelete: Cascade)
 
     tokenAddress            String
     token                   PrismaToken         @relation(fields:[tokenAddress, chain], references: [address, chain])
 
     stakingId               String
-    staking                 PrismaPoolStaking   @relation(fields:[stakingId, chain], references: [id, chain])
+    staking                 PrismaPoolStaking   @relation(fields:[stakingId, chain], references: [id, chain], onDelete: Cascade)
 }
 
 model PrismaUserBalanceSyncStatus {

--- a/modules/vebal/vebal.prisma
+++ b/modules/vebal/vebal.prisma
@@ -31,7 +31,7 @@ model PrismaVotingGauge {
   id      String
   chain   Chain
 
-  stakingGauge      PrismaPoolStakingGauge? @relation(fields: [stakingGaugeId, chain], references: [id, chain])
+  stakingGauge      PrismaPoolStakingGauge? @relation(fields: [stakingGaugeId, chain], references: [id, chain], onDelete: Cascade)
   status            PrismaVotingGaugeStatus @default(ACTIVE)
   gaugeAddress      String
   stakingGaugeId    String?

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
         "@types/uuid": "^8.0.0",
         "concurrently": "^6.4.0",
         "execa": "^4.1.0",
+        "fishery": "^2.2.2",
         "jest": "^28.1.3",
         "jest-watch-typeahead": "^1.0.0",
         "msw": "^0.47.3",

--- a/prisma/migrations/20231221153955_allow_deleting_pools_with_associations/migration.sql
+++ b/prisma/migrations/20231221153955_allow_deleting_pools_with_associations/migration.sql
@@ -1,0 +1,131 @@
+-- DropForeignKey
+ALTER TABLE "PrismaPoolAprItem" DROP CONSTRAINT "PrismaPoolAprItem_poolId_chain_fkey";
+
+-- DropForeignKey
+ALTER TABLE "PrismaPoolAprRange" DROP CONSTRAINT "PrismaPoolAprRange_aprItemId_chain_fkey";
+
+-- DropForeignKey
+ALTER TABLE "PrismaPoolDynamicData" DROP CONSTRAINT "PrismaPoolDynamicData_poolId_chain_fkey";
+
+-- DropForeignKey
+ALTER TABLE "PrismaPoolElementData" DROP CONSTRAINT "PrismaPoolElementData_poolId_chain_fkey";
+
+-- DropForeignKey
+ALTER TABLE "PrismaPoolExpandedTokens" DROP CONSTRAINT "PrismaPoolExpandedTokens_nestedPoolId_chain_fkey";
+
+-- DropForeignKey
+ALTER TABLE "PrismaPoolExpandedTokens" DROP CONSTRAINT "PrismaPoolExpandedTokens_poolId_chain_fkey";
+
+-- DropForeignKey
+ALTER TABLE "PrismaPoolFilterMap" DROP CONSTRAINT "PrismaPoolFilterMap_poolId_chain_fkey";
+
+-- DropForeignKey
+ALTER TABLE "PrismaPoolGyroData" DROP CONSTRAINT "PrismaPoolGyroData_poolId_chain_fkey";
+
+-- DropForeignKey
+ALTER TABLE "PrismaPoolLinearData" DROP CONSTRAINT "PrismaPoolLinearData_poolId_chain_fkey";
+
+-- DropForeignKey
+ALTER TABLE "PrismaPoolLinearDynamicData" DROP CONSTRAINT "PrismaPoolLinearDynamicData_poolId_chain_fkey";
+
+-- DropForeignKey
+ALTER TABLE "PrismaPoolSnapshot" DROP CONSTRAINT "PrismaPoolSnapshot_poolId_chain_fkey";
+
+-- DropForeignKey
+ALTER TABLE "PrismaPoolStableDynamicData" DROP CONSTRAINT "PrismaPoolStableDynamicData_poolId_chain_fkey";
+
+-- DropForeignKey
+ALTER TABLE "PrismaPoolStaking" DROP CONSTRAINT "PrismaPoolStaking_poolId_chain_fkey";
+
+-- DropForeignKey
+ALTER TABLE "PrismaPoolStakingGauge" DROP CONSTRAINT "PrismaPoolStakingGauge_stakingId_chain_fkey";
+
+-- DropForeignKey
+ALTER TABLE "PrismaPoolStakingGaugeReward" DROP CONSTRAINT "PrismaPoolStakingGaugeReward_gaugeId_chain_fkey";
+
+-- DropForeignKey
+ALTER TABLE "PrismaPoolSwap" DROP CONSTRAINT "PrismaPoolSwap_poolId_chain_fkey";
+
+-- DropForeignKey
+ALTER TABLE "PrismaPoolToken" DROP CONSTRAINT "PrismaPoolToken_poolId_chain_fkey";
+
+-- DropForeignKey
+ALTER TABLE "PrismaPoolTokenDynamicData" DROP CONSTRAINT "PrismaPoolTokenDynamicData_poolTokenId_chain_fkey";
+
+-- DropForeignKey
+ALTER TABLE "PrismaUserStakedBalance" DROP CONSTRAINT "PrismaUserStakedBalance_poolId_chain_fkey";
+
+-- DropForeignKey
+ALTER TABLE "PrismaUserStakedBalance" DROP CONSTRAINT "PrismaUserStakedBalance_stakingId_chain_fkey";
+
+-- DropForeignKey
+ALTER TABLE "PrismaUserWalletBalance" DROP CONSTRAINT "PrismaUserWalletBalance_poolId_chain_fkey";
+
+-- DropForeignKey
+ALTER TABLE "PrismaVotingGauge" DROP CONSTRAINT "PrismaVotingGauge_stakingGaugeId_chain_fkey";
+
+-- AddForeignKey
+ALTER TABLE "PrismaPoolLinearData" ADD CONSTRAINT "PrismaPoolLinearData_poolId_chain_fkey" FOREIGN KEY ("poolId", "chain") REFERENCES "PrismaPool"("id", "chain") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PrismaPoolElementData" ADD CONSTRAINT "PrismaPoolElementData_poolId_chain_fkey" FOREIGN KEY ("poolId", "chain") REFERENCES "PrismaPool"("id", "chain") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PrismaPoolGyroData" ADD CONSTRAINT "PrismaPoolGyroData_poolId_chain_fkey" FOREIGN KEY ("poolId", "chain") REFERENCES "PrismaPool"("id", "chain") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PrismaPoolDynamicData" ADD CONSTRAINT "PrismaPoolDynamicData_poolId_chain_fkey" FOREIGN KEY ("poolId", "chain") REFERENCES "PrismaPool"("id", "chain") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PrismaPoolStableDynamicData" ADD CONSTRAINT "PrismaPoolStableDynamicData_poolId_chain_fkey" FOREIGN KEY ("poolId", "chain") REFERENCES "PrismaPool"("id", "chain") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PrismaPoolLinearDynamicData" ADD CONSTRAINT "PrismaPoolLinearDynamicData_poolId_chain_fkey" FOREIGN KEY ("poolId", "chain") REFERENCES "PrismaPool"("id", "chain") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PrismaPoolToken" ADD CONSTRAINT "PrismaPoolToken_poolId_chain_fkey" FOREIGN KEY ("poolId", "chain") REFERENCES "PrismaPool"("id", "chain") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PrismaPoolTokenDynamicData" ADD CONSTRAINT "PrismaPoolTokenDynamicData_poolTokenId_chain_fkey" FOREIGN KEY ("poolTokenId", "chain") REFERENCES "PrismaPoolToken"("id", "chain") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PrismaPoolSwap" ADD CONSTRAINT "PrismaPoolSwap_poolId_chain_fkey" FOREIGN KEY ("poolId", "chain") REFERENCES "PrismaPool"("id", "chain") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PrismaPoolAprItem" ADD CONSTRAINT "PrismaPoolAprItem_poolId_chain_fkey" FOREIGN KEY ("poolId", "chain") REFERENCES "PrismaPool"("id", "chain") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PrismaPoolAprRange" ADD CONSTRAINT "PrismaPoolAprRange_aprItemId_chain_fkey" FOREIGN KEY ("aprItemId", "chain") REFERENCES "PrismaPoolAprItem"("id", "chain") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PrismaPoolExpandedTokens" ADD CONSTRAINT "PrismaPoolExpandedTokens_poolId_chain_fkey" FOREIGN KEY ("poolId", "chain") REFERENCES "PrismaPool"("id", "chain") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PrismaPoolExpandedTokens" ADD CONSTRAINT "PrismaPoolExpandedTokens_nestedPoolId_chain_fkey" FOREIGN KEY ("nestedPoolId", "chain") REFERENCES "PrismaPool"("id", "chain") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PrismaPoolFilterMap" ADD CONSTRAINT "PrismaPoolFilterMap_poolId_chain_fkey" FOREIGN KEY ("poolId", "chain") REFERENCES "PrismaPool"("id", "chain") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PrismaPoolStaking" ADD CONSTRAINT "PrismaPoolStaking_poolId_chain_fkey" FOREIGN KEY ("poolId", "chain") REFERENCES "PrismaPool"("id", "chain") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PrismaPoolStakingGauge" ADD CONSTRAINT "PrismaPoolStakingGauge_stakingId_chain_fkey" FOREIGN KEY ("stakingId", "chain") REFERENCES "PrismaPoolStaking"("id", "chain") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PrismaPoolStakingGaugeReward" ADD CONSTRAINT "PrismaPoolStakingGaugeReward_gaugeId_chain_fkey" FOREIGN KEY ("gaugeId", "chain") REFERENCES "PrismaPoolStakingGauge"("id", "chain") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PrismaPoolSnapshot" ADD CONSTRAINT "PrismaPoolSnapshot_poolId_chain_fkey" FOREIGN KEY ("poolId", "chain") REFERENCES "PrismaPool"("id", "chain") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PrismaUserWalletBalance" ADD CONSTRAINT "PrismaUserWalletBalance_poolId_chain_fkey" FOREIGN KEY ("poolId", "chain") REFERENCES "PrismaPool"("id", "chain") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PrismaUserStakedBalance" ADD CONSTRAINT "PrismaUserStakedBalance_poolId_chain_fkey" FOREIGN KEY ("poolId", "chain") REFERENCES "PrismaPool"("id", "chain") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PrismaUserStakedBalance" ADD CONSTRAINT "PrismaUserStakedBalance_stakingId_chain_fkey" FOREIGN KEY ("stakingId", "chain") REFERENCES "PrismaPoolStaking"("id", "chain") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PrismaVotingGauge" ADD CONSTRAINT "PrismaVotingGauge_stakingGaugeId_chain_fkey" FOREIGN KEY ("stakingGaugeId", "chain") REFERENCES "PrismaPoolStakingGauge"("id", "chain") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20231221154038_more_pool_defaults/migration.sql
+++ b/prisma/migrations/20231221154038_more_pool_defaults/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "PrismaPoolDynamicData" ALTER COLUMN "volume24h" SET DEFAULT 0,
+ALTER COLUMN "fees24h" SET DEFAULT 0;

--- a/prisma/migrations/20231221154118_pools_data_json_column/migration.sql
+++ b/prisma/migrations/20231221154118_pools_data_json_column/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "PrismaPool" ADD COLUMN     "data" JSONB NOT NULL DEFAULT '{}';

--- a/prisma/migrations/20231221154118_pools_data_json_column/migration.sql
+++ b/prisma/migrations/20231221154118_pools_data_json_column/migration.sql
@@ -1,2 +1,2 @@
 -- AlterTable
-ALTER TABLE "PrismaPool" ADD COLUMN     "data" JSONB NOT NULL DEFAULT '{}';
+ALTER TABLE "PrismaPool" ADD COLUMN     "poolTypeSpecificData" JSONB NOT NULL DEFAULT '{}';

--- a/prisma/migrations/20231221154118_pools_data_json_column/migration.sql
+++ b/prisma/migrations/20231221154118_pools_data_json_column/migration.sql
@@ -1,2 +1,2 @@
 -- AlterTable
-ALTER TABLE "PrismaPool" ADD COLUMN     "poolTypeSpecificData" JSONB NOT NULL DEFAULT '{}';
+ALTER TABLE "PrismaPool" ADD COLUMN     "staticTypeData" JSONB NOT NULL DEFAULT '{}';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -111,7 +111,7 @@ model PrismaPoolLinearData {
 
     id                  String
     poolId              String
-    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain])
+    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain], onDelete: Cascade)
     chain               Chain
 
     mainIndex           Int
@@ -124,7 +124,7 @@ model PrismaPoolElementData {
 
     id                  String
     poolId              String
-    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain])
+    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain], onDelete: Cascade)
     chain               Chain
 
     unitSeconds         String
@@ -138,7 +138,7 @@ model PrismaPoolGyroData{
 
     id                  String
     poolId              String
-    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain])
+    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain], onDelete: Cascade)
     chain               Chain
 
     alpha               String
@@ -166,7 +166,7 @@ model PrismaPoolDynamicData {
 
     id                      String
     poolId                  String
-    pool                    PrismaPool          @relation(fields:[poolId, chain], references: [id, chain])
+    pool                    PrismaPool          @relation(fields:[poolId, chain], references: [id, chain], onDelete: Cascade)
     chain                   Chain
     blockNumber             Int
     updatedAt               DateTime            @updatedAt
@@ -220,7 +220,7 @@ model PrismaPoolStableDynamicData {
 
     id                  String
     poolId              String
-    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain])
+    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain], onDelete: Cascade)
     chain               Chain
     blockNumber         Int
     updatedAt           DateTime            @updatedAt
@@ -234,7 +234,7 @@ model PrismaPoolLinearDynamicData {
 
     id                  String
     poolId              String
-    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain])
+    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain], onDelete: Cascade)
     chain               Chain
     blockNumber         Int
     updatedAt           DateTime            @updatedAt
@@ -248,7 +248,7 @@ model PrismaPoolToken {
 
     id                          String
     poolId                      String
-    pool                        PrismaPool          @relation(fields:[poolId, chain], references: [id, chain])
+    pool                        PrismaPool          @relation(fields:[poolId, chain], references: [id, chain], onDelete: Cascade)
     chain                       Chain
 
     address                     String
@@ -270,7 +270,7 @@ model PrismaPoolTokenDynamicData {
 
     id                  String
     poolTokenId         String
-    poolToken           PrismaPoolToken     @relation(fields:[poolTokenId, chain], references: [id, chain])
+    poolToken           PrismaPoolToken     @relation(fields:[poolTokenId, chain], references: [id, chain], onDelete: Cascade)
     chain               Chain
     blockNumber         Int
     updatedAt           DateTime            @updatedAt
@@ -287,7 +287,7 @@ model PrismaPoolSwap {
 
     id                  String
     poolId              String
-    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain])
+    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain], onDelete: Cascade)
     chain               Chain
 
     userAddress         String
@@ -330,7 +330,7 @@ model PrismaPoolAprItem {
 
     id                  String
     poolId              String
-    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain])
+    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain], onDelete: Cascade)
     chain               Chain
     title               String
     apr                 Float
@@ -347,7 +347,7 @@ model PrismaPoolAprRange {
     id                  String
     chain               Chain
     aprItemId           String
-    aprItem             PrismaPoolAprItem   @relation(fields:[aprItemId, chain], references: [id, chain])
+    aprItem             PrismaPoolAprItem   @relation(fields:[aprItemId, chain], references: [id, chain], onDelete: Cascade)
     min                 Float
     max                 Float
 }
@@ -401,11 +401,11 @@ model PrismaPoolExpandedTokens {
     tokenAddress        String
     token               PrismaToken         @relation(fields:[tokenAddress, chain], references: [address, chain])
     poolId              String
-    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain])
+    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain], onDelete: Cascade)
     chain               Chain
 
     nestedPoolId        String?
-    nestedPool          PrismaPool?         @relation(name: "NestedPoolForAllToken", fields:[nestedPoolId, chain], references: [id, chain])
+    nestedPool          PrismaPool?         @relation(name: "NestedPoolForAllToken", fields:[nestedPoolId, chain], references: [id, chain], onDelete: Cascade)
 }
 
 
@@ -427,7 +427,7 @@ model PrismaPoolFilterMap {
     filterId            String
     filter              PrismaPoolFilter    @relation(fields:[filterId, chain], references: [id, chain])
     poolId              String
-    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain])
+    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain], onDelete: Cascade)
 }
 
 model PrismaPoolStaking {
@@ -435,7 +435,7 @@ model PrismaPoolStaking {
 
     id                  String
     poolId              String
-    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain])
+    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain], onDelete: Cascade)
     chain               Chain
     type                PrismaPoolStakingType
     address             String
@@ -485,7 +485,7 @@ model PrismaPoolStakingGauge {
 
     id                  String
     stakingId           String
-    staking             PrismaPoolStaking   @relation(fields:[stakingId, chain], references: [id, chain])
+    staking             PrismaPoolStaking   @relation(fields:[stakingId, chain], references: [id, chain], onDelete: Cascade)
     chain               Chain
 
     gaugeAddress        String
@@ -509,7 +509,7 @@ model PrismaPoolStakingGaugeReward{
 
     id                  String
     gaugeId             String
-    gauge               PrismaPoolStakingGauge @relation(fields:[gaugeId, chain], references: [id, chain])
+    gauge               PrismaPoolStakingGauge @relation(fields:[gaugeId, chain], references: [id, chain], onDelete: Cascade)
     chain               Chain
 
     tokenAddress        String
@@ -556,7 +556,7 @@ model PrismaPoolSnapshot {
 
     id                  String
     poolId              String
-    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain])
+    pool                PrismaPool          @relation(fields:[poolId, chain], references: [id, chain], onDelete: Cascade)
     chain               Chain
     timestamp           Int
 
@@ -787,7 +787,7 @@ model PrismaUserWalletBalance {
     user                    PrismaUser          @relation(fields:[userAddress], references: [address])
 
     poolId                  String?
-    pool                    PrismaPool?         @relation(fields:[poolId, chain], references: [id, chain])
+    pool                    PrismaPool?         @relation(fields:[poolId, chain], references: [id, chain], onDelete: Cascade)
 
     tokenAddress            String
     token                   PrismaToken         @relation(fields:[tokenAddress, chain], references: [address, chain])
@@ -807,13 +807,13 @@ model PrismaUserStakedBalance {
     user                    PrismaUser          @relation(fields:[userAddress], references: [address])
 
     poolId                  String?
-    pool                    PrismaPool?          @relation(fields:[poolId, chain], references: [id, chain])
+    pool                    PrismaPool?          @relation(fields:[poolId, chain], references: [id, chain], onDelete: Cascade)
 
     tokenAddress            String
     token                   PrismaToken         @relation(fields:[tokenAddress, chain], references: [address, chain])
 
     stakingId               String
-    staking                 PrismaPoolStaking   @relation(fields:[stakingId, chain], references: [id, chain])
+    staking                 PrismaPoolStaking   @relation(fields:[stakingId, chain], references: [id, chain], onDelete: Cascade)
 }
 
 model PrismaUserBalanceSyncStatus {
@@ -903,7 +903,7 @@ model PrismaVotingGauge {
   id      String
   chain   Chain
 
-  stakingGauge      PrismaPoolStakingGauge? @relation(fields: [stakingGaugeId, chain], references: [id, chain])
+  stakingGauge      PrismaPoolStakingGauge? @relation(fields: [stakingGaugeId, chain], references: [id, chain], onDelete: Cascade)
   status            PrismaVotingGaugeStatus @default(ACTIVE)
   gaugeAddress      String
   stakingGaugeId    String?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,6 +64,7 @@ model PrismaPool {
     linearData          PrismaPoolLinearData?
     elementData         PrismaPoolElementData?
     gyroData            PrismaPoolGyroData?
+    data                Json @default("{}")
 
     tokens              PrismaPoolToken[]
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -179,8 +179,8 @@ model PrismaPoolDynamicData {
     totalShares             String
     totalSharesNum          Float               @default(0)
     totalLiquidity          Float
-    volume24h               Float
-    fees24h                 Float
+    volume24h               Float               @default(0)
+    fees24h                 Float               @default(0)
     yieldCapture24h         Float               @default(0)
     apr                     Float               @default(0)
     volume48h               Float               @default(0)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,7 +64,7 @@ model PrismaPool {
     linearData          PrismaPoolLinearData?
     elementData         PrismaPoolElementData?
     gyroData            PrismaPoolGyroData?
-    data                Json @default("{}")
+    poolTypeSpecificData Json @default("{}")
 
     tokens              PrismaPoolToken[]
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,7 +64,7 @@ model PrismaPool {
     linearData          PrismaPoolLinearData?
     elementData         PrismaPoolElementData?
     gyroData            PrismaPoolGyroData?
-    poolTypeSpecificData Json @default("{}")
+    staticTypeData Json @default("{}")
 
     tokens              PrismaPoolToken[]
 

--- a/test/factories/index.ts
+++ b/test/factories/index.ts
@@ -1,0 +1,2 @@
+export * from './pool.factory';
+export * from './pool_token.factory';

--- a/test/factories/pool.factory.ts
+++ b/test/factories/pool.factory.ts
@@ -1,0 +1,50 @@
+import { Factory } from 'fishery';
+import { BalancerPoolFragment } from '../../modules/subgraphs/balancer-subgraph/generated/balancer-subgraph-types';
+
+export const poolFactory = Factory.define<BalancerPoolFragment>(() => ({
+    id: '123',
+    poolType: 'A',
+    address: '0x123456789',
+    swapFee: '0.01',
+    totalSwapVolume: '1000',
+    totalSwapFee: '10',
+    totalLiquidity: '10000',
+    totalShares: '100',
+    swapsCount: '5',
+    holdersCount: '10',
+    createTime: 1234567890, // Add createTime property as a number
+    swapEnabled: true, // Add swapEnabled property
+    tokensList: ['token1', 'token2'], // Add tokensList property
+    tokens: [
+        {
+            id: 'token1',
+            symbol: 'T1',
+            name: 'Token 1',
+            decimals: 18,
+            address: 'token1',
+            balance: '100',
+            weight: '0.5',
+            priceRate: '1',
+            index: 0,
+            token: {
+                // token properties...
+            },
+        },
+        {
+            id: 'token2',
+            symbol: 'T2',
+            name: 'Token 2',
+            decimals: 18,
+            address: 'token2',
+            balance: '200',
+            weight: '0.5',
+            priceRate: '1',
+            index: 1,
+            token: {
+                // token properties...
+            },
+        },
+    ],
+
+    // Add other required properties...
+}));

--- a/test/factories/pool_token.factory.ts
+++ b/test/factories/pool_token.factory.ts
@@ -1,0 +1,17 @@
+import { Factory } from 'fishery';
+import { BalancerPoolTokenFragment } from '../../modules/subgraphs/balancer-subgraph/generated/balancer-subgraph-types';
+
+export const poolTokenFactory = Factory.define<BalancerPoolTokenFragment>(() => ({
+    id: 'token1',
+    symbol: 'T1',
+    name: 'Token 1',
+    decimals: 18,
+    address: 'token1',
+    balance: '100',
+    weight: '0.5',
+    priceRate: '1',
+    index: 0,
+    token: {
+        // token properties...
+    },
+}));

--- a/yarn.lock
+++ b/yarn.lock
@@ -7280,6 +7280,13 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+fishery@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/fishery/-/fishery-2.2.2.tgz#94d3d9380295dd3ce555021e9353c5348b8beb77"
+  integrity sha512-jeU0nDhPHJkupmjX+r9niKgVMTBDB8X+U/pktoGHAiWOSyNlMd0HhmqnjrpjUOCDPJYaSSu4Ze16h6dZOKSp2w==
+  dependencies:
+    lodash.mergewith "^4.6.2"
+
 follow-redirects@^1.0.0:
   version "1.15.3"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
@@ -9262,6 +9269,11 @@ lodash.memoize@4.x:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
+lodash.mergewith@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
+  integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
 
 lodash.once@^4.0.0:
   version "4.1.1"


### PR DESCRIPTION
This pull request adds:

* support for FX pools by adding a parser for the subgraph data. In the mapper I'm extracting the structure we had in the pool-creator-service and splitting it into two parts:
  * mapping data from subgraph to DB schema
  * building prisma create object with all the nested tables.
  This helps with testing and adding updates, or upserts will be easier, since we have the clean data object.
* I changed foreign keys constrains related to pools to allow for deleting a pool with all associated records.
* added fishery for setting up object factories in tests