### PR TITLE
SOR: compare local results, not query results

### DIFF
--- a/modules/sor/sor.gql
+++ b/modules/sor/sor.gql
@@ -47,6 +47,7 @@ input GqlSorSwapOptionsInput {
     timestamp: Int #used for caching purposes
     maxPools: Int
     forceRefresh: Boolean #don't use any cached responses
+    queryBatchSwap: Boolean #run queryBatchSwap to update with onchain values
 }
 
 """

--- a/modules/sor/sor.service.ts
+++ b/modules/sor/sor.service.ts
@@ -76,7 +76,7 @@ export class SorService {
 
         try {
             // Updates with latest onchain data before returning
-            return swap.getSorSwapResponse(true);
+            return swap.getSorSwapResponse(args.swapOptions.queryBatchSwap ? args.swapOptions.queryBatchSwap : false);
         } catch (err) {
             console.log(`Error Retrieving QuerySwap`, err);
             return emptyResponse;

--- a/modules/sor/sorV1Beets/sorV1Beets.service.ts
+++ b/modules/sor/sorV1Beets/sorV1Beets.service.ts
@@ -29,7 +29,7 @@ class SwapResultV1 implements SwapResult {
 
     async getSorSwapResponse(queryFirst: boolean): Promise<GqlSorGetSwapsResponse> {
         if (!this.isValid || this.swap === null) throw new Error('No Response - Invalid Swap');
-        // Beets service is already querying onchain
+        // never query onchain for old v1 service
         return this.swap;
     }
 }

--- a/modules/sor/sorV2/sorV2.service.ts
+++ b/modules/sor/sorV2/sorV2.service.ts
@@ -305,11 +305,6 @@ export class SorV2Service implements SwapService {
                           maxNonBoostedPathDepth,
                       },
                   };
-
-            console.info(
-                `SOR: Fetching SORv2 on ${chain} for ${tokenIn} -> ${tokenOut} with maxNonBoostedPathDepth`,
-                maxNonBoostedPathDepth,
-            );
             const swap = await sorGetSwapsWithPools(tIn, tOut, swapKind, swapAmount, poolsFromDb, config);
             if (!swap && maxNonBoostedPathDepth < 5) {
                 return this.getSwapResult(arguments[0], maxNonBoostedPathDepth + 1);


### PR DESCRIPTION
This should help to compare the SOR results, as now both do not query on-chain by default. Before, updated v1 queries where compared to "stale" v2 queries.