### PR TITLE
redo wallet/staked balance query

### DIFF
--- a/modules/user/lib/user-balance.service.ts
+++ b/modules/user/lib/user-balance.service.ts
@@ -27,8 +27,6 @@ export class UserBalanceService {
             where: {
                 userAddress: address.toLowerCase(),
                 chain: { in: chains },
-                poolId: { not: null },
-                balanceNum: { gt: 0 },
             },
         });
 
@@ -36,23 +34,24 @@ export class UserBalanceService {
             where: {
                 userAddress: address.toLowerCase(),
                 chain: { in: chains },
-                poolId: { not: null },
-                balanceNum: { gt: 0 },
             },
         });
 
-        if (userWalletBalances.length === 0 && userStakedBalances.length === 0) {
+        const nonZeroUserWalletBalances = userWalletBalances.filter((balance) => balance.balanceNum > 0);
+        const nonZeroUserStakedBalances = userStakedBalances.filter((balance) => balance.balanceNum > 0);
+
+        if (nonZeroUserWalletBalances.length === 0 && nonZeroUserStakedBalances.length === 0) {
             return [];
         }
 
         const poolIds = _.uniq([
-            ...userStakedBalances.map((balance) => balance.poolId),
-            ...userWalletBalances.map((balance) => balance.poolId),
+            ...nonZeroUserWalletBalances.map((balance) => balance.poolId),
+            ...nonZeroUserStakedBalances.map((balance) => balance.poolId),
         ]) as string[];
 
         return poolIds.map((poolId) => {
-            const stakedBalance = userStakedBalances.find((balance) => balance.poolId === poolId);
-            const walletBalance = userWalletBalances.find((balance) => balance.poolId === poolId);
+            const walletBalance = nonZeroUserWalletBalances.find((balance) => balance.poolId === poolId);
+            const stakedBalance = nonZeroUserStakedBalances.find((balance) => balance.poolId === poolId);
             const stakedNum = parseUnits(stakedBalance?.balance || '0', 18);
             const walletNum = parseUnits(walletBalance?.balance || '0', 18);
 

--- a/modules/user/user.prisma
+++ b/modules/user/user.prisma
@@ -14,6 +14,7 @@ model PrismaUser {
 
 model PrismaUserWalletBalance {
     @@id([id, chain])
+    @@index(userAddress)
 
     id                      String
     chain                   Chain               
@@ -35,6 +36,7 @@ model PrismaUserWalletBalance {
 
 model PrismaUserStakedBalance {
     @@id([id, chain])
+    @@index(userAddress)
 
     id                      String
     chain                   Chain               

--- a/prisma/migrations/20240119115442_user_address_indexes/migration.sql
+++ b/prisma/migrations/20240119115442_user_address_indexes/migration.sql
@@ -1,0 +1,5 @@
+-- CreateIndex
+CREATE INDEX "PrismaUserStakedBalance_userAddress_idx" ON "PrismaUserStakedBalance"("userAddress");
+
+-- CreateIndex
+CREATE INDEX "PrismaUserWalletBalance_userAddress_idx" ON "PrismaUserWalletBalance"("userAddress");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -776,6 +776,7 @@ model PrismaUser {
 
 model PrismaUserWalletBalance {
     @@id([id, chain])
+    @@index(userAddress)
 
     id                      String
     chain                   Chain               
@@ -797,6 +798,7 @@ model PrismaUserWalletBalance {
 
 model PrismaUserStakedBalance {
     @@id([id, chain])
+    @@index(userAddress)
 
     id                      String
     chain                   Chain               


### PR DESCRIPTION
I believe these two queries are currently at the top of the most heavy queries (apart from commit). I wonder if this actually is faster or not. It does not do two joins but instead two queries.

<img width="1159" alt="image" src="https://github.com/balancer/backend/assets/93920061/3794af4f-b4d6-49b2-8724-e4119319938b">

I'm not 100% certain these are the queries reflected.
