### PR TITLE
Change SOR paths output to include required b-sdk input

### DIFF
--- a/modules/sor/sor.gql
+++ b/modules/sor/sor.gql
@@ -1,4 +1,7 @@
 extend type Query {
+    """
+    Get swap quote from the SOR, queries both the old and new SOR
+    """
     sorGetSwaps(
         chain: GqlChain
         tokenIn: String!
@@ -7,18 +10,34 @@ extend type Query {
         swapAmount: BigDecimal! #expected in human readable form
         swapOptions: GqlSorSwapOptionsInput!
     ): GqlSorGetSwapsResponse!
+    """
+    Get swap quote from the SOR v2 for the V2 vault
+    """
     sorV2GetSwaps(
+        """
+        The Chain to query
+        """
         chain: GqlChain!
+        """
+        Token address of the tokenIn
+        """
         tokenIn: String!
         tokenOut: String!
         swapType: GqlSorSwapType!
         swapAmount: BigDecimal! #expected in human readable form
-        swapOptions: GqlSorSwapOptionsInput!
+        queryBatchSwap: Boolean #run queryBatchSwap to update with onchain values, default: true
     ): GqlSorGetSwaps!
 }
 
 type GqlSorGetSwaps {
+    vaultVersion: Int!
+    """
+    The token address of the tokenIn provided
+    """
     tokenIn: String!
+    """
+    The token address of the tokenOut provided
+    """
     tokenOut: String!
     tokenAddresses: [String!]!
     swapType: GqlSorSwapType!

--- a/modules/sor/sor.gql
+++ b/modules/sor/sor.gql
@@ -13,7 +13,7 @@ extend type Query {
     """
     Get swap quote from the SOR v2 for the V2 vault
     """
-    sorV2GetSwaps(
+    sorGetSwapPaths(
         """
         The Chain to query
         """
@@ -26,10 +26,11 @@ extend type Query {
         swapType: GqlSorSwapType!
         swapAmount: BigDecimal! #expected in human readable form
         queryBatchSwap: Boolean #run queryBatchSwap to update with onchain values, default: true
-    ): GqlSorGetSwaps!
+        useVaultVersion: Int #defaults that it gets the best swap from v2 and v3, can force to use only one vault version
+    ): GqlSorGetSwapPaths!
 }
 
-type GqlSorGetSwaps {
+type GqlSorGetSwapPaths {
     vaultVersion: Int!
     """
     The token address of the tokenIn provided
@@ -39,9 +40,8 @@ type GqlSorGetSwaps {
     The token address of the tokenOut provided
     """
     tokenOut: String!
-    tokenAddresses: [String!]!
-    swapType: GqlSorSwapType!
-    swaps: [GqlSorSwap!]!
+    swaps: [GqlSorSwap!]! #used by cowswap
+    paths: [GqlSorPath!]! #used by b-sdk
     tokenInAmount: AmountHumanReadable!
     tokenOutAmount: AmountHumanReadable!
     swapAmount: AmountHumanReadable!
@@ -52,6 +52,19 @@ type GqlSorGetSwaps {
     effectivePriceReversed: AmountHumanReadable!
     routes: [GqlSorSwapRoute!]!
     priceImpact: AmountHumanReadable!
+}
+
+type GqlSorPath {
+    vaultVersion: Int!
+    pools: [String]! #list of pool Ids
+    tokens: [Token]!
+    outputAmountRaw: String!
+    inputAmountRaw: String!
+}
+
+type Token {
+    address: String!
+    decimals: Int!
 }
 
 enum GqlSorSwapType {
@@ -119,6 +132,7 @@ type GqlSorGetSwapsResponse {
     priceImpact: AmountHumanReadable!
 }
 
+#used by cowswap
 type GqlSorSwap {
     poolId: String!
     assetInIndex: Int!

--- a/modules/sor/sor.resolvers.ts
+++ b/modules/sor/sor.resolvers.ts
@@ -16,8 +16,8 @@ const balancerSdkResolvers: Resolvers = {
 
             return sorService.getSorSwaps(args);
         },
-        sorV2GetSwaps: async (parent, args, context) => {
-            return sorService.getSorV2Swaps(args);
+        sorGetSwapPaths: async (parent, args, context) => {
+            return sorService.getSorSwapPaths(args);
         },
     },
 };

--- a/modules/sor/sor.service.ts
+++ b/modules/sor/sor.service.ts
@@ -47,10 +47,10 @@ export class SorService {
         return sorV2Service.getSorSwaps({
             chain: args.chain!,
             swapAmount: amount,
-            swapOptions: args.swapOptions,
             swapType: args.swapType,
             tokenIn: tokenIn,
             tokenOut: tokenOut,
+            queryBatchSwap: args.queryBatchSwap ? args.queryBatchSwap : true,
         });
     }
 

--- a/modules/sor/sor.service.ts
+++ b/modules/sor/sor.service.ts
@@ -2,8 +2,8 @@ import {
     GqlSorSwapType,
     GqlSorGetSwapsResponse,
     QuerySorGetSwapsArgs,
-    GqlSorGetSwaps,
-    QuerySorV2GetSwapsArgs,
+    QuerySorGetSwapPathsArgs,
+    GqlSorGetSwapPaths,
 } from '../../schema';
 import { sorV1BeetsService } from './sorV1Beets/sorV1Beets.service';
 import { sorV2Service } from './sorV2/sorV2.service';
@@ -12,15 +12,15 @@ import * as Sentry from '@sentry/node';
 import { Chain } from '@prisma/client';
 import { parseUnits, formatUnits } from '@ethersproject/units';
 import { tokenService } from '../token/token.service';
-import { getToken, getTokenAmountHuman, zeroResponse, zeroResponseV2 } from './utils';
+import { getToken, getTokenAmountHuman, zeroResponse, swapPathsZeroResponse } from './utils';
 
 export class SorService {
-    async getSorV2Swaps(args: QuerySorV2GetSwapsArgs): Promise<GqlSorGetSwaps> {
+    async getSorSwapPaths(args: QuerySorGetSwapPathsArgs): Promise<GqlSorGetSwapPaths> {
         console.log('getSorSwaps args', JSON.stringify(args));
         const tokenIn = args.tokenIn.toLowerCase();
         const tokenOut = args.tokenOut.toLowerCase();
         const amountToken = args.swapType === 'EXACT_IN' ? tokenIn : tokenOut;
-        const emptyResponse = zeroResponseV2(args.swapType, args.tokenIn, args.tokenOut);
+        const emptyResponse = swapPathsZeroResponse(args.tokenIn, args.tokenOut);
 
         // check if tokens addresses exist
         try {
@@ -44,7 +44,7 @@ export class SorService {
         // args.swapAmount is HumanScale
         const amount = await getTokenAmountHuman(amountToken, args.swapAmount, args.chain!);
 
-        return sorV2Service.getSorSwaps({
+        return sorV2Service.getSorSwapPaths({
             chain: args.chain!,
             swapAmount: amount,
             swapType: args.swapType,

--- a/modules/sor/sorV2/beetsHelpers.ts
+++ b/modules/sor/sorV2/beetsHelpers.ts
@@ -1,6 +1,7 @@
-import { BatchSwapStep, NATIVE_ADDRESS, SingleSwap, SwapKind, ZERO_ADDRESS } from '@balancer/sdk';
-import { GqlPoolMinimal, GqlSorSwapRoute, GqlSorSwapRouteHop } from '../../../schema';
+import { BatchSwapStep, NATIVE_ADDRESS, SingleSwap, Swap, SwapKind, ZERO_ADDRESS } from '@balancer/sdk';
+import { GqlPoolMinimal, GqlSorPath, GqlSorSwapRoute, GqlSorSwapRouteHop } from '../../../schema';
 import { formatFixed } from '@ethersproject/bignumber';
+import path from 'path';
 
 export function mapRoutes(
     swaps: BatchSwapStep[] | SingleSwap,
@@ -20,6 +21,25 @@ export function mapRoutes(
     }
     const paths = splitPaths(swaps, assetIn, assetOut, assets, kind);
     return paths.map((p) => mapBatchSwap(p, amountIn, amountOut, kind, assets, pools));
+}
+
+export function mapPaths(swap: Swap): GqlSorPath[] {
+    const paths: GqlSorPath[] = [];
+
+    for (const path of swap.paths) {
+        paths.push({
+            vaultVersion: 2,
+            inputAmountRaw: path.inputAmount.amount.toString(),
+            outputAmountRaw: path.outputAmount.amount.toString(),
+            tokens: path.tokens.map((token) => ({
+                address: token.address,
+                decimals: token.decimals,
+            })),
+            pools: path.pools.map((pool) => pool.id),
+        });
+    }
+
+    return paths;
 }
 
 export function mapBatchSwap(

--- a/modules/sor/types.ts
+++ b/modules/sor/types.ts
@@ -11,6 +11,16 @@ export interface GetSwapsInput {
     graphTraversalConfig?: GraphTraversalConfig;
 }
 
+export interface GetSwapsV2Input {
+    chain: Chain;
+    tokenIn: string;
+    tokenOut: string;
+    swapType: GqlSorSwapType;
+    swapAmount: TokenAmount;
+    queryBatchSwap: boolean;
+    graphTraversalConfig?: GraphTraversalConfig;
+}
+
 export interface GraphTraversalConfig {
     approxPathsToReturn?: number;
     maxDepth?: number;

--- a/modules/sor/utils.ts
+++ b/modules/sor/utils.ts
@@ -1,7 +1,7 @@
 import { tokenService } from '../token/token.service';
 import { Chain } from '@prisma/client';
 import { AllNetworkConfigsKeyedOnChain, chainToIdMap } from '../network/network-config';
-import { GqlSorGetSwaps, GqlSorGetSwapsResponse, GqlSorSwapType } from '../../schema';
+import { GqlSorGetSwapPaths, GqlSorGetSwapsResponse, GqlSorSwapType } from '../../schema';
 import { replaceZeroAddressWithEth } from '../web3/addresses';
 import { Address } from 'viem';
 import { NATIVE_ADDRESS, Token, TokenAmount } from '@balancer/sdk';
@@ -37,13 +37,13 @@ export const getToken = async (tokenAddr: string, chain: Chain): Promise<Token> 
     }
 };
 
-export const zeroResponseV2 = (swapType: GqlSorSwapType, tokenIn: string, tokenOut: string): GqlSorGetSwaps => {
+export const swapPathsZeroResponse = (tokenIn: string, tokenOut: string): GqlSorGetSwapPaths => {
     return {
-        tokenAddresses: [],
         swaps: [],
+        paths: [],
+        vaultVersion: 2,
         tokenIn: replaceZeroAddressWithEth(tokenIn),
         tokenOut: replaceZeroAddressWithEth(tokenOut),
-        swapType,
         tokenInAmount: '0',
         tokenOutAmount: '0',
         swapAmount: '0',


### PR DESCRIPTION
Now returns an array of GqlSorPath:

```
type GqlSorPath {
    vaultVersion: Int!
    pools: [String]! #list of pool Ids
    tokens: [Token]!
    outputAmountRaw: String!
    inputAmountRaw: String!
}

type Token {
    address: String!
    decimals: Int!
}
```

Also changed input to also take a vault version (uses both and returns best result by default)