### PR TITLE
Add-sDOLA-APR-endpoint-mainnet

### DIFF
--- a/modules/network/mainnet.ts
+++ b/modules/network/mainnet.ts
@@ -349,6 +349,12 @@ export const data: NetworkData = {
                 path: 'value',
                 isIbYield: true,
             },
+            sDOLA: {
+                tokenAddress: '0xb45ad160634c528Cc3D2926d9807104FA3157305',
+                sourceUrl: 'https://https://www.inverse.finance/api/dola-staking',
+                path: 'apr',
+                isIbYield: true,
+            },
         },
     },
     beefy: {


### PR DESCRIPTION
Adding apr path for sDOLA, token: https://etherscan.io/address/0xb45ad160634c528cc3d2926d9807104fa3157305 and endpoint:   https://https://www.inverse.finance/api/dola-staking

Pool: https://app.balancer.fi/#/ethereum/pool/0x264062ca46a1322c2e6464471764089e01f22f1900000000000000000000066b