### PR TITLE
update-ggaAvax-apr-endpoint

### DIFF
--- a/modules/network/avalanche.ts
+++ b/modules/network/avalanche.ts
@@ -163,13 +163,13 @@ const avalancheNetworkData: NetworkData = {
             },
             ggAVAX: {
                 tokenAddress: '0xa25eaf2906fa1a3a13edac9b9657108af7b703e3',
-                sourceUrl: 'https://ceres.gogopool.com',
-                path: 'ggAVAXMonthlyInterestMonth.value',
+                sourceUrl: 'https://api.gogopool.com/metrics',
+                path: 'ggavax_apy',
+                // Updated from https://ceres.gogopool.com/ which used below calculation and scale -8.3333
                 // According to solarcurve, the AVAX Monthly Interest must be multiplied by -12 to represent the APR in normal scale, for example, if the monthly interest is -0,15, the APR would be -0,15 * -12 = 1,8%.
                 // @solarcurve: We estimate by multiplying that value by -12 since its the exchange rate of AVAX -> ggAVAX, which will always return less ggAVAX than AVAX
                 // How this -12 became -8,333? It's because the scale parameter is used to divide the number, and the final apr percentage is in decimal format (1,8% = 0,018), so if:
                 // M * -12 = A (M is monthly rate and A is APR) => (M/x) = (A/100) => (A / -12x) = (A / 100) [replacing M by A/-12] => x = 100/-12 = -8,33333
-                scale: -8.3333,
             },
             ankrAVAX: {
                 tokenAddress: '0xc3344870d52688874b06d844e0c36cc39fc727f6',


### PR DESCRIPTION
Per GGP team new endpoint to utilize will be https://api.gogopool.com/metrics as they are deprecating https://ceres.gogopool.com. Please confirm path is correct prior to merging. LGTM.