### PR TITLE
Hotfix: add sDOLA to exclusion list

### DIFF
--- a/modules/network/mainnet.ts
+++ b/modules/network/mainnet.ts
@@ -59,7 +59,7 @@ export const data: NetworkData = {
         platformId: 'ethereum',
         excludedTokenAddresses: [
             '0x04c154b66cb340f3ae24111cc767e0184ed00cc6', // pxETH, has Coingecko entry but no price
-            '0x865377367054516e17014CcdED1e7d814EDC9ce4', // sDOLA, has Coingecko entry but no price
+            '0xb45ad160634c528Cc3D2926d9807104FA3157305', // sDOLA, has Coingecko entry but no price
         ],
     },
     rpcUrl:

--- a/modules/network/mainnet.ts
+++ b/modules/network/mainnet.ts
@@ -58,7 +58,8 @@ export const data: NetworkData = {
         nativeAssetId: 'ethereum',
         platformId: 'ethereum',
         excludedTokenAddresses: [
-            '0x04c154b66cb340f3ae24111cc767e0184ed00cc6', // pxETH, has coingekco entry but no price
+            '0x04c154b66cb340f3ae24111cc767e0184ed00cc6', // pxETH, has Coingecko entry but no price
+            '0x865377367054516e17014CcdED1e7d814EDC9ce4', // sDOLA, has Coingecko entry but no price
         ],
     },
     rpcUrl:

--- a/modules/network/mainnet.ts
+++ b/modules/network/mainnet.ts
@@ -59,7 +59,7 @@ export const data: NetworkData = {
         platformId: 'ethereum',
         excludedTokenAddresses: [
             '0x04c154b66cb340f3ae24111cc767e0184ed00cc6', // pxETH, has Coingecko entry but no price
-            '0xb45ad160634c528Cc3D2926d9807104FA3157305', // sDOLA, has Coingecko entry but no price
+            '0xb45ad160634c528cc3d2926d9807104fa3157305', // sDOLA, has Coingecko entry but no price
         ],
     },
     rpcUrl:


### PR DESCRIPTION
- Exclude sDOLA so that pricing information is properly handled as there is a coingecko id but not price
- Affected pool: https://app.balancer.fi/#/ethereum/pool/0x264062ca46a1322c2e6464471764089e01f22f1900000000000000000000066b