### PR TITLE
Handle positive price impact

### DIFF
--- a/modules/sor/sorV2/lib/utils/helpers.ts
+++ b/modules/sor/sorV2/lib/utils/helpers.ts
@@ -45,12 +45,12 @@ export function calculatePriceImpact(paths: PathWithAmount[], swapKind: SwapKind
             ),
     );
 
-    const amountInitial = swapKind === SwapKind.GivenIn ? getInputAmount(paths).amount : getOutputAmount(paths).amount;
+    const amountInitial = swapKind === SwapKind.GivenIn ? getInputAmount(paths).amount : getInputAmount(pathsReverse).amount;
 
     const amountFinal =
-        swapKind === SwapKind.GivenIn ? getOutputAmount(pathsReverse).amount : getInputAmount(pathsReverse).amount;
+        swapKind === SwapKind.GivenIn ? getOutputAmount(pathsReverse).amount : getOutputAmount(paths).amount;
 
-    const priceImpact = MathSol.divDownFixed(abs(amountInitial - amountFinal), amountInitial * 2n);
+    const priceImpact = MathSol.divDownFixed(amountInitial - amountFinal, amountInitial * 2n);
     return PriceImpactAmount.fromRawAmount(priceImpact);
 }
 


### PR DESCRIPTION
Current price impact implementation does not properly handle scenarios with "positive" price impact. This update aims to handle that by returning a negative amount when that happens.