### PR TITLE
override coingecko IDs from github repo

### DIFF
--- a/modules/content/content-types.ts
+++ b/modules/content/content-types.ts
@@ -46,9 +46,9 @@ export interface HomeScreenNewsItem {
 }
 
 export interface ContentService {
-    syncTokenContentData(): Promise<void>;
-    syncPoolContentData(): Promise<void>;
+    syncTokenContentData(chains: Chain[]): Promise<void>;
+    syncPoolContentData(chain: Chain): Promise<void>;
     getFeaturedPoolGroups(chains: Chain[]): Promise<HomeScreenFeaturedPoolGroup[]>;
     getFeaturedPools(chains: Chain[]): Promise<FeaturedPool[]>;
-    getNewsItems(): Promise<HomeScreenNewsItem[]>;
+    getNewsItems(chain: Chain): Promise<HomeScreenNewsItem[]>;
 }

--- a/modules/content/content.gql
+++ b/modules/content/content.gql
@@ -1,5 +1,5 @@
 extend type Query {
-    contentGetNewsItems: [GqlContentNewsItem!]!
+    contentGetNewsItems(chain: GqlChain): [GqlContentNewsItem!]!
 }
 
 type GqlContentNewsItem {

--- a/modules/content/content.resolvers.ts
+++ b/modules/content/content.resolvers.ts
@@ -1,10 +1,17 @@
 import { Resolvers } from '../../schema';
+import { headerChain } from '../context/header-chain';
 import { networkContext } from '../network/network-context.service';
 
 const contentResolvers: Resolvers = {
     Query: {
-        contentGetNewsItems: async () => {
-            return await networkContext.config.contentService.getNewsItems();
+        contentGetNewsItems: async (parent, { chain }, context) => {
+            const currentChain = headerChain();
+            if (!chain && currentChain) {
+                chain = currentChain;
+            } else if (!chain) {
+                throw new Error('contentGetNewsItems error: Provide "chain" param');
+            }
+            return await networkContext.config.contentService.getNewsItems(chain);
         },
     },
 };

--- a/modules/content/github-content.service.ts
+++ b/modules/content/github-content.service.ts
@@ -2,10 +2,10 @@ import { isSameAddress } from '@balancer-labs/sdk';
 import { Chain, Prisma } from '@prisma/client';
 import axios from 'axios';
 import { prisma } from '../../prisma/prisma-client';
-import { networkContext } from '../network/network-context.service';
 import { ContentService, FeaturedPool, HomeScreenFeaturedPoolGroup, HomeScreenNewsItem } from './content-types';
 import { chainIdToChain } from '../network/chain-id-to-chain';
 import { LinearData } from '../pool/subgraph-mapper';
+import { chainToIdMap } from '../network/network-config';
 
 const POOLS_METADATA_URL = 'https://raw.githubusercontent.com/balancer/metadata/main/pools/featured.json';
 
@@ -30,143 +30,105 @@ interface WhitelistedToken {
     symbol: string;
     decimals: number;
     logoURI: string;
+    extensions?: {
+        coingeckoId?: string;
+    };
 }
 
-const sepoliaTokens: Record<string, { symbol: string; coingeckoTokenId: string }> = {
-    '0xb19382073c7a0addbb56ac6af1808fa49e377b75': {
-        symbol: 'BAL',
-        coingeckoTokenId: 'balancer',
-    },
-    '0xb77eb1a70a96fdaaeb31db1b42f2b8b5846b2613': {
-        symbol: 'DAI',
-        coingeckoTokenId: 'dai',
-    },
-    '0x7b79995e5f793a07bc00c21412e50ecae098e7f9': {
-        symbol: 'WETH',
-        coingeckoTokenId: 'weth',
-    },
-    '0x80d6d3946ed8a1da4e226aa21ccddc32bd127d1a': {
-        symbol: 'USDC',
-        coingeckoTokenId: 'usd-coin',
-    },
-    '0x6bf294b80c7d8dc72dee762af5d01260b756a051': {
-        symbol: 'USDT',
-        coingeckoTokenId: 'tether',
-    },
-    '0x23bad11f1543503cb1fb5dad05fdaf93f42d30f3': {
-        symbol: 'EURS',
-        coingeckoTokenId: 'stasis-eurs',
-    },
-    '0x0f409e839a6a790aecb737e4436293be11717f95': {
-        symbol: 'BEETS',
-        coingeckoTokenId: 'beethoven-x',
-    },
-    '0xc3745bce4b5d0977dc874832bc99108d416dce8f': {
-        symbol: 'WBTC',
-        coingeckoTokenId: 'wrapped-bitcoin',
-    },
-};
-
-//TODO implement other content functions
 export class GithubContentService implements ContentService {
-    async syncTokenContentData(): Promise<void> {
+    async syncTokenContentData(chains: Chain[]): Promise<void> {
         const { data: githubAllTokenList } = await axios.get<WhitelistedTokenList>(TOKEN_LIST_URL);
 
-        const filteredTokenList = githubAllTokenList.tokens.filter((token) => {
-            if (`${token.chainId}` !== networkContext.chainId) {
-                return false;
-            }
-
-            const requiredKeys = ['chainId', 'address', 'name', 'symbol', 'decimals'];
-            return requiredKeys.every((key) => token?.[key as keyof WhitelistedToken] != null);
-        });
-
-        for (const githubToken of filteredTokenList) {
-            const tokenAddress = githubToken.address.toLowerCase();
-            let coingeckoTokenId = null;
-
-            if (networkContext.chain === 'SEPOLIA') {
-                if (sepoliaTokens[tokenAddress]) {
-                    coingeckoTokenId = sepoliaTokens[tokenAddress].coingeckoTokenId;
+        for (const chain of chains) {
+            const filteredTokenList = githubAllTokenList.tokens.filter((token) => {
+                if (`${token.chainId}` !== chainToIdMap[chain]) {
+                    return false;
                 }
-            }
 
-            // only override coingecko ID if it's present
-            let update = {};
-            if (coingeckoTokenId) {
-                update = {
-                    name: githubToken.name,
-                    symbol: githubToken.symbol,
-                    logoURI: { set: githubToken.logoURI || null },
-                    coingeckoTokenId: coingeckoTokenId,
-                };
-            } else {
-                update = {
-                    name: githubToken.name,
-                    symbol: githubToken.symbol,
-                    logoURI: { set: githubToken.logoURI || null },
-                };
-            }
-
-            await prisma.prismaToken.upsert({
-                where: {
-                    address_chain: { address: tokenAddress, chain: networkContext.chain },
-                },
-                create: {
-                    name: githubToken.name,
-                    address: tokenAddress,
-                    chain: networkContext.chain,
-                    symbol: githubToken.symbol,
-                    decimals: githubToken.decimals,
-                    logoURI: githubToken.logoURI,
-                    coingeckoPlatformId: null,
-                    coingeckoContractAddress: null,
-                    coingeckoTokenId: coingeckoTokenId,
-                    description: null,
-                    websiteUrl: null,
-                    discordUrl: null,
-                    telegramUrl: null,
-                    twitterUsername: null,
-                },
-                update: update,
+                const requiredKeys = ['chainId', 'address', 'name', 'symbol', 'decimals'];
+                return requiredKeys.every((key) => token?.[key as keyof WhitelistedToken] != null);
             });
+
+            for (const githubToken of filteredTokenList) {
+                const tokenAddress = githubToken.address.toLowerCase();
+
+                await prisma.prismaToken.upsert({
+                    where: {
+                        address_chain: { address: tokenAddress, chain: chain },
+                    },
+                    create: {
+                        name: githubToken.name,
+                        address: tokenAddress,
+                        chain: chainIdToChain[githubToken.chainId],
+                        symbol: githubToken.symbol,
+                        decimals: githubToken.decimals,
+                        logoURI: githubToken.logoURI,
+                        coingeckoTokenId: githubToken.extensions?.coingeckoId,
+                        coingeckoPlatformId: null,
+                        coingeckoContractAddress: null,
+                        description: null,
+                        websiteUrl: null,
+                        discordUrl: null,
+                        telegramUrl: null,
+                        twitterUsername: null,
+                    },
+                    update: {
+                        name: githubToken.name,
+                        address: tokenAddress,
+                        chain: chainIdToChain[githubToken.chainId],
+                        symbol: githubToken.symbol,
+                        decimals: githubToken.decimals,
+                        logoURI: githubToken.logoURI,
+                        coingeckoTokenId: githubToken.extensions?.coingeckoId,
+                        // coingeckoPlatformId: null,
+                        // coingeckoContractAddress: null,
+                        // description: null,
+                        // websiteUrl: null,
+                        // discordUrl: null,
+                        // telegramUrl: null,
+                        // twitterUsername: null,
+                    },
+                });
+            }
+
+            const whiteListedTokens = await prisma.prismaTokenType.findMany({
+                where: {
+                    type: 'WHITE_LISTED',
+                    chain: chain,
+                },
+            });
+
+            const addToWhitelist = filteredTokenList.filter((githubToken) => {
+                return !whiteListedTokens.some((dbToken) => isSameAddress(githubToken.address, dbToken.tokenAddress));
+            });
+
+            const removeFromWhitelist = whiteListedTokens.filter((dbToken) => {
+                return !filteredTokenList.some((githubToken) =>
+                    isSameAddress(dbToken.tokenAddress, githubToken.address),
+                );
+            });
+
+            await prisma.prismaTokenType.createMany({
+                data: addToWhitelist.map((token) => ({
+                    id: `${token.address}-white-listed`,
+                    chain: chain,
+                    tokenAddress: token.address.toLowerCase(),
+                    type: 'WHITE_LISTED' as const,
+                })),
+                skipDuplicates: true,
+            });
+
+            await prisma.prismaTokenType.deleteMany({
+                where: { id: { in: removeFromWhitelist.map((token) => token.id) }, chain: chain },
+            });
+
+            await this.syncTokenTypes(chain);
         }
-
-        const whiteListedTokens = await prisma.prismaTokenType.findMany({
-            where: {
-                type: 'WHITE_LISTED',
-                chain: networkContext.chain,
-            },
-        });
-
-        const addToWhitelist = filteredTokenList.filter((githubToken) => {
-            return !whiteListedTokens.some((dbToken) => isSameAddress(githubToken.address, dbToken.tokenAddress));
-        });
-
-        const removeFromWhitelist = whiteListedTokens.filter((dbToken) => {
-            return !filteredTokenList.some((githubToken) => isSameAddress(dbToken.tokenAddress, githubToken.address));
-        });
-
-        await prisma.prismaTokenType.createMany({
-            data: addToWhitelist.map((token) => ({
-                id: `${token.address}-white-listed`,
-                chain: networkContext.chain,
-                tokenAddress: token.address.toLowerCase(),
-                type: 'WHITE_LISTED' as const,
-            })),
-            skipDuplicates: true,
-        });
-
-        await prisma.prismaTokenType.deleteMany({
-            where: { id: { in: removeFromWhitelist.map((token) => token.id) }, chain: networkContext.chain },
-        });
-
-        await this.syncTokenTypes();
     }
 
-    private async syncTokenTypes() {
+    private async syncTokenTypes(chain: Chain) {
         const pools = await prisma.prismaPool.findMany({
-            where: { chain: networkContext.chain },
+            where: { chain: chain },
             select: {
                 address: true,
                 symbol: true,
@@ -178,7 +140,7 @@ export class GithubContentService implements ContentService {
         });
         const tokens = await prisma.prismaToken.findMany({
             include: { types: true },
-            where: { chain: networkContext.chain },
+            where: { chain: chain },
         });
         const types: Prisma.PrismaTokenTypeCreateManyInput[] = [];
 
@@ -189,7 +151,7 @@ export class GithubContentService implements ContentService {
             if (pool && !tokenTypes.includes('BPT')) {
                 types.push({
                     id: `${token.address}-bpt`,
-                    chain: networkContext.chain,
+                    chain: chain,
                     type: 'BPT',
                     tokenAddress: token.address,
                 });
@@ -201,7 +163,7 @@ export class GithubContentService implements ContentService {
             ) {
                 types.push({
                     id: `${token.address}-phantom-bpt`,
-                    chain: networkContext.chain,
+                    chain: chain,
                     type: 'PHANTOM_BPT',
                     tokenAddress: token.address,
                 });
@@ -215,7 +177,7 @@ export class GithubContentService implements ContentService {
             if (wrappedLinearPoolToken && !tokenTypes.includes('LINEAR_WRAPPED_TOKEN')) {
                 types.push({
                     id: `${token.address}-linear-wrapped`,
-                    chain: networkContext.chain,
+                    chain: chain,
                     type: 'LINEAR_WRAPPED_TOKEN',
                     tokenAddress: token.address,
                 });
@@ -223,14 +185,15 @@ export class GithubContentService implements ContentService {
 
             if (!wrappedLinearPoolToken && tokenTypes.includes('LINEAR_WRAPPED_TOKEN')) {
                 prisma.prismaTokenType.delete({
-                    where: { id_chain: { id: `${token.address}-linear-wrapped`, chain: networkContext.chain } },
+                    where: { id_chain: { id: `${token.address}-linear-wrapped`, chain: chain } },
                 });
             }
         }
 
         await prisma.prismaTokenType.createMany({ skipDuplicates: true, data: types });
     }
-    async syncPoolContentData(): Promise<void> {}
+
+    async syncPoolContentData(chain: Chain): Promise<void> {}
 
     async getFeaturedPoolGroups(chains: Chain[]): Promise<HomeScreenFeaturedPoolGroup[]> {
         return [];
@@ -246,7 +209,7 @@ export class GithubContentService implements ContentService {
         })) as FeaturedPool[];
     }
 
-    async getNewsItems(): Promise<HomeScreenNewsItem[]> {
+    async getNewsItems(chain: Chain): Promise<HomeScreenNewsItem[]> {
         return [];
     }
 }

--- a/modules/pool/pool.service.ts
+++ b/modules/pool/pool.service.ts
@@ -247,7 +247,7 @@ export class PoolService {
     }
 
     public async syncPoolContentData() {
-        await this.contentService.syncPoolContentData();
+        await this.contentService.syncPoolContentData(this.chain);
     }
 
     public async syncStakingForPools() {

--- a/modules/token/token.service.ts
+++ b/modules/token/token.service.ts
@@ -26,7 +26,7 @@ export class TokenService {
     public async syncTokenContentData() {
         //sync coingecko Ids first, then override Ids from the content service
         await this.coingeckoDataService.syncCoingeckoIds();
-        await networkContext.config.contentService.syncTokenContentData();
+        await networkContext.config.contentService.syncTokenContentData([networkContext.chain]);
     }
 
     public async getToken(address: string, chain = networkContext.chain): Promise<PrismaToken | null> {
@@ -250,7 +250,7 @@ export class TokenService {
         await prisma.prismaTokenType.deleteMany({
             where: { chain: networkContext.chain },
         });
-        await networkContext.config.contentService.syncTokenContentData();
+        await networkContext.config.contentService.syncTokenContentData([networkContext.chain]);
     }
 }
 


### PR DESCRIPTION
We can now override coingecko IDs from the tokenlists repo to introduce reference pricing or exclude tokens from being priced via coingecko.
Once the content service for Beets also moves to the tokenlist, we can deprecate the sanity content service. 

solves #232 and addresses part of #18 