### PR TITLE
add updateBy and updatedAt to current token prices

### DIFF
--- a/modules/token/lib/token-price-handlers/fallback-price-handler.service.ts
+++ b/modules/token/lib/token-price-handlers/fallback-price-handler.service.ts
@@ -40,7 +40,8 @@ export class FallbackHandlerService implements TokenPriceHandler {
                             update: {
                                 price: price.price,
                                 close: price.price,
-                                updatedBy: this.id,
+                                updatedAt: price.updatedAt,
+                                updatedBy: price.updatedBy,
                             },
                             create: {
                                 tokenAddress: token.address,
@@ -51,7 +52,8 @@ export class FallbackHandlerService implements TokenPriceHandler {
                                 low: price.price,
                                 open: price.price,
                                 close: price.price,
-                                updatedBy: this.id,
+                                updatedAt: price.updatedAt,
+                                updatedBy: price.updatedBy,
                             },
                         }),
                     );

--- a/modules/token/lib/token-price.service.ts
+++ b/modules/token/lib/token-price.service.ts
@@ -16,7 +16,6 @@ import { BptPriceHandlerService } from './token-price-handlers/bpt-price-handler
 import { SwapsPriceHandlerService } from './token-price-handlers/swaps-price-handler.service';
 import { PrismaTokenWithTypes } from '../../../prisma/prisma-types';
 import { AavePriceHandlerService } from './token-price-handlers/aave-price-handler.service';
-import { DAYS_OF_HOURLY_PRICES } from '../../../config';
 import config from '../../../config';
 
 export class TokenPriceService {

--- a/modules/token/token.gql
+++ b/modules/token/token.gql
@@ -41,6 +41,8 @@ type GqlTokenPrice {
     address: String!
     chain: GqlChain!
     price: Float!
+    updatedAt: Int!
+    updatedBy: String
 }
 
 type GqlHistoricalTokenPrice {

--- a/modules/token/token.gql
+++ b/modules/token/token.gql
@@ -54,6 +54,8 @@ type GqlHistoricalTokenPrice {
 type GqlHistoricalTokenPriceEntry {
     timestamp: String!
     price: Float!
+    updatedAt: Int!
+    updatedBy: String
 }
 
 type GqlToken {

--- a/modules/token/token.resolvers.ts
+++ b/modules/token/token.resolvers.ts
@@ -30,6 +30,7 @@ const resolvers: Resolvers = {
                 address: price.tokenAddress,
                 price: price.price,
                 chain: price.chain,
+                updatedAt: price.updatedAt.getTime(),
             }));
         },
         tokenGetHistoricalPrices: async (parent, { addresses, chain, range }, context) => {

--- a/modules/token/token.resolvers.ts
+++ b/modules/token/token.resolvers.ts
@@ -46,6 +46,8 @@ const resolvers: Resolvers = {
                     prices: grouped[address].map((entry) => ({
                         timestamp: `${entry.timestamp}`,
                         price: entry.price,
+                        updatedAt: entry.updatedAt.getTime(),
+                        updatedBy: entry.updatedBy,
                     })),
                 });
             }

--- a/modules/token/token.service.ts
+++ b/modules/token/token.service.ts
@@ -127,17 +127,6 @@ export class TokenService {
     }
 
     public async getWhiteListedTokenPrices(chains: Chain[]): Promise<PrismaTokenCurrentPrice[]> {
-        /*const cached = this.cache.get(WHITE_LISTED_TOKEN_PRICES_CACHE_KEY) as PrismaTokenCurrentPrice[] | null;
-
-        if (cached) {
-            return cached;
-        }
-
-        const tokenPrices = await this.tokenPriceService.getWhiteListedCurrentTokenPrices();
-        this.cache.put(WHITE_LISTED_TOKEN_PRICES_CACHE_KEY, tokenPrices, 10000);
-
-        return tokenPrices;*/
-
         return this.tokenPriceService.getWhiteListedCurrentTokenPrices(chains);
     }
 


### PR DESCRIPTION
- fallback price handler does not set itself as the pricehandler but copies this from the former price as well
- updatedAt and updatedBy added to current prices. Do we need to add it to historical prices as well?

solves #315 
