### PR TITLE
jitoSOL-APR-Endpoint

### DIFF
--- a/config/arbitrum.ts
+++ b/config/arbitrum.ts
@@ -187,6 +187,13 @@ export default <NetworkData>{
                 path: 'stakingYield.value',
                 isIbYield: true,
             },
+            jitoSOL: {
+                tokenAddress: '0x211cc4dd073734da055fbf44a2b4667d5e5fe5d2',
+                sourceUrl: 'https://kobe.mainnet.jito.network/api/v1/stake_pool_stats',
+                path: 'apr.0.data',
+                scale: 1,
+                isIbYield: true,
+            },
         },
     },
     beefy: {


### PR DESCRIPTION
            jitoSOL: {
                tokenAddress: '0x211cc4dd073734da055fbf44a2b4667d5e5fe5d2',
                sourceUrl: 'https://kobe.mainnet.jito.network/api/v1/stake_pool_stats',
                path: 'apr.0.data',
                scale: 1,
                isIbYield: true,
            },