### PR TITLE
osETH Arbitrum

### DIFF
--- a/config/arbitrum.ts
+++ b/config/arbitrum.ts
@@ -131,7 +131,7 @@ export default <NetworkData>{
                 },
             },
         },
-        stakewise: '0xf7d4e7273E5015C96728A6b02f31C505eE184603',
+        stakewise: '0xf7d4e7273e5015c96728a6b02f31c505ee184603',
         defaultHandlers: {
             wstETH: {
                 tokenAddress: '0x5979d7b546e38e414f7e9822514be443a4800529',

--- a/config/arbitrum.ts
+++ b/config/arbitrum.ts
@@ -131,6 +131,7 @@ export default <NetworkData>{
                 },
             },
         },
+        stakewise: '0xf7d4e7273E5015C96728A6b02f31C505eE184603',
         defaultHandlers: {
             wstETH: {
                 tokenAddress: '0x5979d7b546e38e414f7e9822514be443a4800529',


### PR DESCRIPTION
Address config and address for osETH on Arbitrum.

Pool: https://app.balancer.fi/#/arbitrum/pool/0x42f7cfc38dd1583ffda2e4f047f4f6fa06cefc7c000000000000000000000553  
Token: https://arbiscan.io/address/0xf7d4e7273e5015c96728a6b02f31c505ee184603  
Source (same as mainnet): const url = 'https://mainnet-graph.stakewise.io/subgraphs/name/stakewise/stakewise'

I am not sure this url will work properly if it passes the Arbitrum token address via the config file. Please correct as needed. 