### PR TITLE
gUSDC-APR-Arbitrum

### DIFF
--- a/.changeset/tidy-mirrors-sing.md
+++ b/.changeset/tidy-mirrors-sing.md
@@ -1,0 +1,5 @@
+---
+'backend': patch
+---
+
+add gUSDC apr

--- a/config/arbitrum.ts
+++ b/config/arbitrum.ts
@@ -206,6 +206,12 @@ export default <NetworkData>{
                 path: 'value',
                 isIbYield: true,
             },
+            gUSDC: {
+                tokenAddress: '0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0',
+                sourceUrl: 'https://backend-arbitrum.gains.trade/apr',
+                path: 'collateralRewards.{symbol == "USDC"}.vaultApr',
+                isIbYield: true,
+            },
         },
     },
     gyro: {


### PR DESCRIPTION
Based on this PR: https://github.com/balancer/yield-tokens/pulls

Pool: https://app.balancer.fi/#/arbitrum/pool/0xe8a6026365254f779b6927f00f8724ea1b8ae5e0000000000000000000000580

Token: https://arbiscan.io/address/0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0

Endpoint: https://backend-arbitrum.gains.trade/apr VaultAPR is 15.3% per Gains Network UI.

Please check my request method.