### PR TITLE
Adding Missing APRs

### DIFF
--- a/.changeset/happy-owls-develop.md
+++ b/.changeset/happy-owls-develop.md
@@ -1,0 +1,5 @@
+---
+'backend': patch
+---
+
+add weETH APR on Arb and rETH APR on Gnosis

--- a/config/arbitrum.ts
+++ b/config/arbitrum.ts
@@ -127,6 +127,7 @@ export default <NetworkData>{
             },
         },
         stakewise: '0xf7d4e7273e5015c96728a6b02f31c505ee184603',
+        etherfi: '0x35751007a407ca6feffe80b3cb397736d2cf4dbe',
         defaultHandlers: {
             wstETH: {
                 tokenAddress: '0x5979d7b546e38e414f7e9822514be443a4800529',

--- a/config/gnosis.ts
+++ b/config/gnosis.ts
@@ -72,6 +72,12 @@ export default <NetworkData>{
                 path: 'data.smaApr',
                 isIbYield: true,
             },
+            rETH: {
+                tokenAddress: '0xc791240d1f2def5938e2031364ff4ed887133c3d',
+                sourceUrl: 'https://rocketpool.net/api/mainnet/payload',
+                path: 'rethAPR',
+                isIbYield: true,
+            },
         },
     },
     gyro: {


### PR DESCRIPTION
rETH on Gnosis and weETH on Arbitrum APRs missing per Gyroscope requests.

See PR: https://github.com/balancer/yield-tokens/pull/17