### PR TITLE
Fix scientific notation issue caused by parseFloat

### DIFF
--- a/.changeset/afraid-boats-help.md
+++ b/.changeset/afraid-boats-help.md
@@ -1,0 +1,5 @@
+---
+'backend': patch
+---
+
+Fix scientific notation issue caused by parseFloat

--- a/modules/sor/sorV2/sorPathService.ts
+++ b/modules/sor/sorV2/sorPathService.ts
@@ -273,7 +273,7 @@ class SorPathService implements SwapService {
                         swapKind,
                         expectedAmountIn: inputAmount,
                     },
-                    slippage: Slippage.fromPercentage(`${parseFloat(callDataInput.slippagePercentage)}`),
+                    slippage: Slippage.fromPercentage(callDataInput.slippagePercentage as `${number}`),
                     deadline: callDataInput.deadline ? BigInt(callDataInput.deadline) : 999999999999999999n,
                 }) as SwapBuildOutputExactOut;
                 callData = {


### PR DESCRIPTION
Closes #781 