### PR TITLE
fix: Enable Stable pools for non-V3 liquidity.

### DIFF
--- a/.changeset/little-birds-cry.md
+++ b/.changeset/little-birds-cry.md
@@ -1,0 +1,5 @@
+---
+'backend': patch
+---
+
+Enable Stable pools for non-V3 in SOR.

--- a/modules/sor/sorV2/lib/static.ts
+++ b/modules/sor/sorV2/lib/static.ts
@@ -37,11 +37,7 @@ export async function sorGetPathsWithPools(
                 basePools.push(ComposableStablePool.fromPrismaPool(prismaPool));
                 break;
             case 'STABLE':
-                {
-                    if (prismaPool.protocolVersion === 3) {
-                        basePools.push(StablePool.fromPrismaPool(prismaPool));
-                    }
-                }
+                basePools.push(StablePool.fromPrismaPool(prismaPool));
                 break;
             case 'META_STABLE':
                 basePools.push(MetaStablePool.fromPrismaPool(prismaPool));


### PR DESCRIPTION
I don't have any context on why these were originally disabled for non-V3 pools but by doing that we cut out a lot of potential liquidity (e.g. [auraBal/8020BPT](https://zen.balancer.fi/pools/ethereum/v2/0x3dd0843a028c86e0b760b1a76929d1c5ef93a2dd000200000000000000000249) which is causing issues for auraBal swaps). I've tested a bunch of swaps and haven't come across any issues.