### PR TITLE
chore: rename polygon native asset from MATIC to POL

### DIFF
--- a/.changeset/fuzzy-panthers-lie.md
+++ b/.changeset/fuzzy-panthers-lie.md
@@ -1,0 +1,5 @@
+---
+'backend': patch
+---
+
+rename polygon native asset from MATIC to POL

--- a/config/polygon.ts
+++ b/config/polygon.ts
@@ -23,8 +23,8 @@ export default <NetworkData>{
     eth: {
         address: '0x0000000000000000000000000000000000001010',
         addressFormatted: '0x0000000000000000000000000000000000001010',
-        symbol: 'MATIC',
-        name: 'Matic',
+        symbol: 'POL',
+        name: 'Polygon Token',
     },
     weth: {
         address: '0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270',


### PR DESCRIPTION
Not sure if `coingecko` already supports `pol` so that we can also change it here: 
https://github.com/balancer/backend/blob/7f3e6e2e673535a180b25eab4132484bbaaf107c/config/polygon.ts#L34