### PR TITLE
feat: allow stable pool routing for v3

### DIFF
--- a/.changeset/wise-dodos-sell.md
+++ b/.changeset/wise-dodos-sell.md
@@ -1,0 +1,5 @@
+---
+"backend": patch
+---
+
+feat: allow stable pool routing for v3

--- a/modules/sor/sorV2/lib/static.ts
+++ b/modules/sor/sorV2/lib/static.ts
@@ -43,7 +43,7 @@ export async function sorGetPathsWithPools(
                     [
                         '0x3dd0843a028c86e0b760b1a76929d1c5ef93a2dd000200000000000000000249', // auraBal/8020
                         '0x2d011adf89f0576c9b722c28269fcb5d50c2d17900020000000000000000024d', // sdBal/8020
-                    ].includes(prismaPool.id)
+                    ].includes(prismaPool.id) || protocolVersion === 3
                 ) {
                     basePools.push(StablePool.fromPrismaPool(prismaPool));
                 }


### PR DESCRIPTION
This pr allows the sor to consider stable pools for v3 swaps. while maintaining the narrow pool liquidity for v2 swaps. This pr is required for e2e swap testing with buffers on this ticket https://github.com/balancer/b-sdk/issues/420. 