### PR TITLE
Fix Dola/USDC swap

### DIFF
--- a/.changeset/slimy-flowers-fry.md
+++ b/.changeset/slimy-flowers-fry.md
@@ -1,0 +1,5 @@
+---
+'backend': patch
+---
+
+SOR - Add support to Dola/USDC stable swap

--- a/modules/sor/sorV2/lib/static.ts
+++ b/modules/sor/sorV2/lib/static.ts
@@ -45,6 +45,7 @@ export async function sorGetPathsWithPools(
                     [
                         '0x3dd0843a028c86e0b760b1a76929d1c5ef93a2dd000200000000000000000249', // auraBal/8020
                         '0x2d011adf89f0576c9b722c28269fcb5d50c2d17900020000000000000000024d', // sdBal/8020
+                        '0xff4ce5aaab5a627bf82f4a571ab1ce94aa365ea6000200000000000000000426', // dola/usdc
                     ].includes(prismaPool.id) ||
                     protocolVersion === 3
                 ) {

--- a/modules/subgraphs/beets-bar-subgraph/generated/beets-bar-subgraph-types.ts
+++ b/modules/subgraphs/beets-bar-subgraph/generated/beets-bar-subgraph-types.ts
@@ -17,7 +17,13 @@ export type Scalars = {
     BigInt: string;
     Bytes: string;
     Int8: any;
+    Timestamp: any;
 };
+
+export enum Aggregation_Interval {
+    Day = 'day',
+    Hour = 'hour',
+}
 
 export type Bar = {
     __typename?: 'Bar';
@@ -459,6 +465,8 @@ export type _Block_ = {
     hash?: Maybe<Scalars['Bytes']>;
     /** The block number */
     number: Scalars['Int'];
+    /** The hash of the parent block */
+    parentHash?: Maybe<Scalars['Bytes']>;
     /** Integer representation of the timestamp stored in blocks for the chain */
     timestamp?: Maybe<Scalars['Int']>;
 };


### PR DESCRIPTION
Closes #1159 

SOR is not picking up DOLA/USDC liquidity because the relevant pool is a Stable pool, which is not a pool type broadly supported by the SOR.

This PR adds the DOLA/USDC pool to be considered by the path finding algorithm.

Note: should we support all relevant Stable pools without the need to add one by one?