### PR TITLE
Deprecate callDataInput, queryBatchSwap and callData from SOR request/response

### DIFF
--- a/.changeset/old-lies-know.md
+++ b/.changeset/old-lies-know.md
@@ -1,0 +1,5 @@
+---
+'backend': patch
+---
+
+Deprecate callData related inputs and outputs from SOR

--- a/graphql_schema_generated.ts
+++ b/graphql_schema_generated.ts
@@ -2548,7 +2548,7 @@ export const schema = gql`
         """
         Transaction data that can be posted to an RPC to execute the swap.
         """
-        callData: GqlSorCallData
+        callData: GqlSorCallData @deprecated(reason: "Use Balancer SDK to build swap callData from SOR response")
 
         """
         The price of tokenOut in tokenIn.
@@ -3477,6 +3477,7 @@ export const schema = gql`
             Input data to create and return transaction data. If this config is given, call data is added to the response.
             """
             callDataInput: GqlSwapCallDataInput
+                @deprecated(reason: "Use Balancer SDK to build swap callData from SOR response")
 
             """
             The Chain to query
@@ -3491,7 +3492,7 @@ export const schema = gql`
             """
             Whether to run queryBatchSwap to update the return amount with most up-to-date on-chain values, default: false
             """
-            queryBatchSwap: Boolean
+            queryBatchSwap: Boolean @deprecated(reason: "Use Balancer SDK to query on-chain amounts from SOR response")
 
             """
             The amount to swap, in human form.

--- a/modules/sor/sor.gql
+++ b/modules/sor/sor.gql
@@ -55,7 +55,7 @@ extend type Query {
         """
         Whether to run queryBatchSwap to update the return amount with most up-to-date on-chain values, default: false
         """
-        queryBatchSwap: Boolean
+        queryBatchSwap: Boolean @deprecated(reason: "Use Balancer SDK to query on-chain amounts from SOR response")
         """
         Which protocol version to use (currently 2 and 3). If none provided, will chose the better return from any version
         """
@@ -68,6 +68,7 @@ extend type Query {
         Input data to create and return transaction data. If this config is given, call data is added to the response.
         """
         callDataInput: GqlSwapCallDataInput
+            @deprecated(reason: "Use Balancer SDK to build swap callData from SOR response")
     ): GqlSorGetSwapPaths!
 }
 
@@ -151,7 +152,7 @@ type GqlSorGetSwapPaths {
     """
     Transaction data that can be posted to an RPC to execute the swap.
     """
-    callData: GqlSorCallData
+    callData: GqlSorCallData @deprecated(reason: "Use Balancer SDK to build swap callData from SOR response")
 }
 
 """

--- a/modules/sor/sorV2/sorPathService.ts
+++ b/modules/sor/sorV2/sorPathService.ts
@@ -237,7 +237,6 @@ class SorPathService implements SwapService {
         let outputAmount = getOutputAmount(paths);
 
         let callData: GqlSorCallData | undefined = undefined;
-        let callDataError: string | undefined = undefined;
 
         // TODO: deprecated on-chain query and callData functionality will be supported for v2 for a while, but should be removed in the future
         if (protocolVersion === 2) {
@@ -301,11 +300,7 @@ class SorPathService implements SwapService {
                         maxAmountInRaw: callDataExactOut.maxAmountIn.amount.toString(),
                     };
                 }
-            } else {
-                callDataError = 'callDataInput is required to provide callData';
             }
-        } else {
-            callDataError = 'callData is only supported for protocolVersion 2';
         }
 
         // TODO: replace price impact ABA with USD values approach (same as used in the FE)
@@ -380,7 +375,6 @@ class SorPathService implements SwapService {
                 error: priceImpactError,
             },
             callData,
-            callDataError,
         };
     }
 

--- a/modules/sources/subgraphs/sftmx-subgraph/generated/sftmx-subgraph-types.ts
+++ b/modules/sources/subgraphs/sftmx-subgraph/generated/sftmx-subgraph-types.ts
@@ -17,7 +17,13 @@ export type Scalars = {
     BigInt: string;
     Bytes: string;
     Int8: any;
+    Timestamp: any;
 };
+
+export enum Aggregation_Interval {
+    day = 'day',
+    hour = 'hour',
+}
 
 export type BlockChangedFilter = {
     number_gte: Scalars['Int'];
@@ -823,6 +829,8 @@ export type _Block_ = {
     hash?: Maybe<Scalars['Bytes']>;
     /** The block number */
     number: Scalars['Int'];
+    /** The hash of the parent block */
+    parentHash?: Maybe<Scalars['Bytes']>;
     /** Integer representation of the timestamp stored in blocks for the chain */
     timestamp?: Maybe<Scalars['Int']>;
 };

--- a/schema.ts
+++ b/schema.ts
@@ -1808,11 +1808,6 @@ export interface GqlSorGetSwapPaths {
      * @deprecated Use Balancer SDK to build swap callData from SOR response
      */
     callData?: Maybe<GqlSorCallData>;
-    /**
-     * Error message incase there was an error in the callData generation.
-     * @deprecated Use Balancer SDK to build swap callData from SOR response
-     */
-    callDataError?: Maybe<Scalars['String']>;
     /** The price of tokenOut in tokenIn. */
     effectivePrice: Scalars['AmountHumanReadable'];
     /** The price of tokenIn in tokenOut. */
@@ -2553,15 +2548,9 @@ export interface QuerySftmxGetWithdrawalRequestsArgs {
 }
 
 export interface QuerySorGetSwapPathsArgs {
-    /**
-     * @deprecated Use Balancer SDK to build swap callData from SOR response
-     */
     callDataInput?: InputMaybe<GqlSwapCallDataInput>;
     chain: GqlChain;
     considerPoolsWithHooks?: InputMaybe<Scalars['Boolean']>;
-    /**
-     * @deprecated Use Balancer SDK to query on-chain amounts from SOR response
-     */
     queryBatchSwap?: InputMaybe<Scalars['Boolean']>;
     swapAmount: Scalars['AmountHumanReadable'];
     swapType: GqlSorSwapType;

--- a/schema.ts
+++ b/schema.ts
@@ -1803,8 +1803,16 @@ export interface GqlSorCallData {
 /** The swap paths for a swap */
 export interface GqlSorGetSwapPaths {
     __typename?: 'GqlSorGetSwapPaths';
-    /** Transaction data that can be posted to an RPC to execute the swap. */
+    /**
+     * Transaction data that can be posted to an RPC to execute the swap.
+     * @deprecated Use Balancer SDK to build swap callData from SOR response
+     */
     callData?: Maybe<GqlSorCallData>;
+    /**
+     * Error message incase there was an error in the callData generation.
+     * @deprecated Use Balancer SDK to build swap callData from SOR response
+     */
+    callDataError?: Maybe<Scalars['String']>;
     /** The price of tokenOut in tokenIn. */
     effectivePrice: Scalars['AmountHumanReadable'];
     /** The price of tokenIn in tokenOut. */
@@ -2545,9 +2553,15 @@ export interface QuerySftmxGetWithdrawalRequestsArgs {
 }
 
 export interface QuerySorGetSwapPathsArgs {
+    /**
+     * @deprecated Use Balancer SDK to build swap callData from SOR response
+     */
     callDataInput?: InputMaybe<GqlSwapCallDataInput>;
     chain: GqlChain;
     considerPoolsWithHooks?: InputMaybe<Scalars['Boolean']>;
+    /**
+     * @deprecated Use Balancer SDK to query on-chain amounts from SOR response
+     */
     queryBatchSwap?: InputMaybe<Scalars['Boolean']>;
     swapAmount: Scalars['AmountHumanReadable'];
     swapType: GqlSorSwapType;


### PR DESCRIPTION
Closes #1177 