### PR TITLE
Apply fix from old sor

### DIFF
--- a/.changeset/beige-forks-prove.md
+++ b/.changeset/beige-forks-prove.md
@@ -1,0 +1,5 @@
+---
+'backend': patch
+---
+
+fixes gyro math implementation

--- a/modules/sor/sorV2/lib/poolsV2/gyroE/gyroEMathHelpers.ts
+++ b/modules/sor/sorV2/lib/poolsV2/gyroE/gyroEMathHelpers.ts
@@ -153,24 +153,30 @@ export function checkAssetBounds(
 function maxBalances0(p: GyroEParams, d: DerivedGyroEParams, r: Vector2) {
     const termXp1 = MathGyro.divXpU(d.tauBeta.x - d.tauAlpha.x, d.dSq);
     const termXp2 = MathGyro.divXpU(d.tauBeta.y - d.tauAlpha.y, d.dSq);
-    let xp = MathGyro.mulDownXpToNpU(MathGyro.mulDownMagU(MathGyro.mulDownMagU(r.y, p.lambda), p.c), termXp1);
-    xp =
-        xp +
-        (termXp2 > 0n
-            ? MathGyro.mulDownMagU(r.y, p.s)
-            : MathGyro.mulDownXpToNpU(MathGyro.mulUpMagU(r.x, p.s), termXp2));
+    let xp = MathGyro.mulDownXpToNpU(
+        MathGyro.mulDownMagU(MathGyro.mulDownMagU(r.y, p.lambda), p.c),
+        termXp1
+    );
+    xp = xp + (
+        termXp2 > 0n
+            ? MathGyro.mulDownXpToNpU(MathGyro.mulDownMagU(r.y, p.s), termXp2)
+            : MathGyro.mulDownXpToNpU(MathGyro.mulUpMagU(r.x, p.s), termXp2)
+    );
     return xp;
 }
 
 function maxBalances1(p: GyroEParams, d: DerivedGyroEParams, r: Vector2) {
     const termXp1 = MathGyro.divXpU(d.tauBeta.x - d.tauAlpha.x, d.dSq);
     const termXp2 = MathGyro.divXpU(d.tauBeta.y - d.tauAlpha.y, d.dSq);
-    let yp = MathGyro.mulDownXpToNpU(MathGyro.mulDownMagU(MathGyro.mulDownMagU(r.y, p.lambda), p.s), termXp1);
-    yp =
-        yp +
-        (termXp2 > 0n
-            ? MathGyro.mulDownMagU(r.y, p.c)
-            : MathGyro.mulDownXpToNpU(MathGyro.mulUpMagU(r.x, p.c), termXp2));
+    let yp = MathGyro.mulDownXpToNpU(
+        MathGyro.mulDownMagU(MathGyro.mulDownMagU(r.y, p.lambda), p.s),
+        termXp1
+    );
+    yp = yp + (
+        termXp2 > 0n
+            ? MathGyro.mulDownXpToNpU(MathGyro.mulDownMagU(r.y, p.c), termXp2)
+            : MathGyro.mulDownXpToNpU(MathGyro.mulUpMagU(r.x, p.c), termXp2)
+    );
     return yp;
 }
 


### PR DESCRIPTION
Fixes #1567 

The issue was that the fix from https://github.com/balancer/balancer-sor/commit/c2693e25a6d1545dc5f4a5a65e4346df924453ad had to be applied to the gyro math in this repo.

I reproduced the issue on the base network. 
- Failing queryBatchSwap: https://www.tdly.co/shared/simulation/cb0864ae-9053-44b6-8fc4-1ae6618813b4
- Reverting Gyro library: https://www.tdly.co/shared/simulation/46237950-b61e-4386-84df-54941c281853

I created the `Swap` with SOR data and queried it resulting in
```
  "data": {
    "abiItem": {
      "inputs": [
        {
          "name": "message",
          "type": "string",
        },
      ],
      "name": "Error",
      "type": "error",
    },
    "args": [
      "GYR#357",
    ],
    "errorName": "Error",
  },
  "details": undefined,
  "docsPath": undefined,
  "metaMessages": undefined,
  "raw": "0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000074759522333353700000000000000000000000000000000000000000000000000",
  "reason": "GYR#357",
  "shortMessage": "The contract function "queryBatchSwap" reverted with the following reason:
GYR#357",
  "signature": undefined,
  "version": "2.23.2",
  "walk": "Function<walk>",
}
```

After applying the fix, the issue does not arise anymore. 