### PR TITLE
SOR - Fix underlying token not found

### DIFF
--- a/.changeset/lazy-guests-press.md
+++ b/.changeset/lazy-guests-press.md
@@ -1,0 +1,5 @@
+---
+'backend': patch
+---
+
+SOR - Fix underlying token not found

--- a/modules/sor/lib/poolsV3/weighted/weightedPool.ts
+++ b/modules/sor/lib/poolsV3/weighted/weightedPool.ts
@@ -70,7 +70,16 @@ export class WeightedPoolV3 extends BasePoolV3 implements BasePoolMethodsV3 {
                         ),
                     );
                 } else {
-                    throw new Error('SOR - ERC4626 underlying token not found');
+                    console.error('SOR - ERC4626 underlying token not found', poolToken.token.underlyingTokenAddress);
+                    poolTokens.push(
+                        new WeightedPoolTokenWithRate(
+                            token,
+                            tokenAmount.amount,
+                            poolToken.index,
+                            parseEther(poolToken.priceRate),
+                            parseEther(poolToken.weight),
+                        ),
+                    );
                 }
             } else {
                 poolTokens.push(

--- a/modules/sor/sor-debug.test.ts
+++ b/modules/sor/sor-debug.test.ts
@@ -53,12 +53,12 @@ describe('sor debugging', () => {
 
         const swaps = await sorService.getSorSwapPaths({
             chain,
-            tokenIn: '0x039e2fB66102314Ce7b64Ce5Ce3E5183bc94aD38', // wS
-            tokenOut: '0x29219dd400f2Bf60E5a23d13Be72B486D4038894', // USDC.e
+            tokenIn: '0xfa85fe5a8f5560e9039c04f2b0a90de1415abd70', // wanS
+            tokenOut: '0x871a101dcf22fe4fe37be7b654098c801cba1c88', // beS
             swapType: 'EXACT_IN',
-            swapAmount: '0.001',
+            swapAmount: '10',
             useProtocolVersion,
-            poolIds: ['0x0af8ea4de2ecfb962cdbb66033a46afe99836994'],
+            // poolIds: ['0x5cd1ab566d0f03c6aab84b96f6076a276390c0bd'],
         });
 
         console.log(swaps.returnAmount);


### PR DESCRIPTION
When underlying token data is not found in the DB, SOR is not able to handle it properly.

Initial solution was throwing an error, but this means that a single inconsistent token data will break the whole SOR.

The solution applied was to consider that token inexistent for that pool, which will prevent routes with that token, but that's ok given the missing data.

It's also logging an error to help identify and fix these issues in the future.