### PR TITLE
fix: enforce lbp pool type usage

### DIFF
--- a/.changeset/pretty-forks-relax.md
+++ b/.changeset/pretty-forks-relax.md
@@ -1,0 +1,5 @@
+---
+'backend': patch
+---
+
+fix duplicate lbp entry in switch statement

--- a/modules/sor/lib/sor.ts
+++ b/modules/sor/lib/sor.ts
@@ -57,8 +57,6 @@ export class SOR {
             try {
                 switch (prismaPool.type) {
                     case 'WEIGHTED':
-                    /// LBPs can be handled like weighted pools
-                    case 'LIQUIDITY_BOOTSTRAPPING':
                         {
                             if (prismaPool.protocolVersion === 2) {
                                 basePools.push(WeightedPool.fromPrismaPool(prismaPool));
@@ -68,6 +66,7 @@ export class SOR {
                         }
                         break;
                     case 'LIQUIDITY_BOOTSTRAPPING': {
+                        /// LBPs use weighted math
                         if (prismaPool.protocolVersion === 2) {
                             basePools.push(WeightedPool.fromPrismaPool(prismaPool));
                         } else {


### PR DESCRIPTION
Removed the duplicate LBP entry in the switch statement