### PR TITLE
fix: reverse order

### DIFF
--- a/.changeset/three-hats-sing.md
+++ b/.changeset/three-hats-sing.md
@@ -1,0 +1,5 @@
+---
+'backend': patch
+---
+
+fix: align maxBalances1 helper with contract logic

--- a/modules/sor/lib/poolsV2/gyroE/gyroEMathHelpers.ts
+++ b/modules/sor/lib/poolsV2/gyroE/gyroEMathHelpers.ts
@@ -153,30 +153,24 @@ export function checkAssetBounds(
 function maxBalances0(p: GyroEParams, d: DerivedGyroEParams, r: Vector2) {
     const termXp1 = MathGyro.divXpU(d.tauBeta.x - d.tauAlpha.x, d.dSq);
     const termXp2 = MathGyro.divXpU(d.tauBeta.y - d.tauAlpha.y, d.dSq);
-    let xp = MathGyro.mulDownXpToNpU(
-        MathGyro.mulDownMagU(MathGyro.mulDownMagU(r.y, p.lambda), p.c),
-        termXp1
-    );
-    xp = xp + (
-        termXp2 > 0n
+    let xp = MathGyro.mulDownXpToNpU(MathGyro.mulDownMagU(MathGyro.mulDownMagU(r.y, p.lambda), p.c), termXp1);
+    xp =
+        xp +
+        (termXp2 > 0n
             ? MathGyro.mulDownXpToNpU(MathGyro.mulDownMagU(r.y, p.s), termXp2)
-            : MathGyro.mulDownXpToNpU(MathGyro.mulUpMagU(r.x, p.s), termXp2)
-    );
+            : MathGyro.mulDownXpToNpU(MathGyro.mulUpMagU(r.x, p.s), termXp2));
     return xp;
 }
 
 function maxBalances1(p: GyroEParams, d: DerivedGyroEParams, r: Vector2) {
     const termXp1 = MathGyro.divXpU(d.tauBeta.x - d.tauAlpha.x, d.dSq);
-    const termXp2 = MathGyro.divXpU(d.tauBeta.y - d.tauAlpha.y, d.dSq);
-    let yp = MathGyro.mulDownXpToNpU(
-        MathGyro.mulDownMagU(MathGyro.mulDownMagU(r.y, p.lambda), p.s),
-        termXp1
-    );
-    yp = yp + (
-        termXp2 > 0n
+    const termXp2 = MathGyro.divXpU(d.tauAlpha.y - d.tauBeta.y, d.dSq);
+    let yp = MathGyro.mulDownXpToNpU(MathGyro.mulDownMagU(MathGyro.mulDownMagU(r.y, p.lambda), p.s), termXp1);
+    yp =
+        yp +
+        (termXp2 > 0n
             ? MathGyro.mulDownXpToNpU(MathGyro.mulDownMagU(r.y, p.c), termXp2)
-            : MathGyro.mulDownXpToNpU(MathGyro.mulUpMagU(r.x, p.c), termXp2)
-    );
+            : MathGyro.mulDownXpToNpU(MathGyro.mulUpMagU(r.x, p.c), termXp2));
     return yp;
 }
 

--- a/modules/sor/lib/sor.ts
+++ b/modules/sor/lib/sor.ts
@@ -119,13 +119,6 @@ export class SOR {
                         if (protocolVersion === 3) {
                             basePools.push(GyroECLPPool.fromPrismaPool(prismaPool));
                         } else {
-                            // one of the Gyro2 pools has no eth left and is out of balance. Temp fix to get SOR working again
-                            // while investigation is ongoing
-                            if (
-                                prismaPool.id === '0x63fc054159094583a27632361bd11c94c30e48c70002000000000000000006f7'
-                            ) {
-                                break;
-                            }
                             basePools.push(GyroEPool.fromPrismaPool(prismaPool));
                         }
                         break;


### PR DESCRIPTION
This pr replaces variables. Closes https://github.com/balancer/backend/issues/2209

What is does:
Fix Gyro pool balance check: align maxBalances1 helper with contract logic

This change corrects an inconsistency between the maxBalances1 helper implementation in the TypeScript code and the on-chain Solidity version. The helper previously used tauBeta.y - tauAlpha.y instead of tauAlpha.y - tauBeta.y, causing incorrect bounds checks in unbalanced pools.

Now, checkAssetBounds behaves as expected.


See this chat for context: https://balancerecosystem.slack.com/archives/C02F9EMRKQA/p1752274866665979.

With this change the pool now correctly throws in `checkAssetBounds`.

The issue is the Gyro pool is out of balance. The `maxBalances1` function is implemented as
```solidity
/** Maximal value for the real reserves y when the respective other balance is 0 for given invariant
     *  See calculation in Section 2.1.2. Calculation is ordered here for precision, but erorr in r is magnified by lambda
     *  Rounds down in signed direction */
    function maxBalances1(
        Params memory p,
        DerivedParams memory d,
        Vector2 memory r // overestimate in x-component, underestimate in y-component
    ) internal pure returns (int256 yp) {
        // y^+ = r lambda s (tau(beta)_x - tau(alpha)_x) + rc (tau(alpha)_y - tau(beta)_y)
        //      account for 1 factors of dSq (2 s,c factors)
        int256 termXp1 = (d.tauBeta.x - d.tauAlpha.x).divXpU(d.dSq); // note tauBeta.x > tauAlpha.x
        int256 termXp2 = (d.tauAlpha.y - d.tauBeta.y).divXpU(d.dSq);
        yp = r.y.mulDownMagU(p.lambda).mulDownMagU(p.s).mulDownXpToNpU(termXp1);
        yp = yp + (termXp2 > 0 ? r.y.mulDownMagU(p.c) : r.x.mulUpMagU(p.c)).mulDownXpToNpU(termXp2);
    }
```

whereas `maxBalances1` is implemented in the helpers as
```typescript
function maxBalances1(p: GyroEParams, d: DerivedGyroEParams, r: Vector2) {
    const termXp1 = MathGyro.divXpU(d.tauBeta.x - d.tauAlpha.x, d.dSq);
    const termXp2 = MathGyro.divXpU(d.tauBeta.y - d.tauAlpha.y, d.dSq);
    let yp = MathGyro.mulDownXpToNpU(
        MathGyro.mulDownMagU(MathGyro.mulDownMagU(r.y, p.lambda), p.s),
        termXp1
    );
    yp = yp + (
        termXp2 > 0n
            ? MathGyro.mulDownXpToNpU(MathGyro.mulDownMagU(r.y, p.c), termXp2)
            : MathGyro.mulDownXpToNpU(MathGyro.mulUpMagU(r.x, p.c), termXp2)
    );
    return yp;
}
```

