### PR TITLE
fix: forward swapKind so limits can be calced accurately

### DIFF
--- a/.changeset/fair-dogs-dream.md
+++ b/.changeset/fair-dogs-dream.md
@@ -1,0 +1,5 @@
+---
+"backend": patch
+---
+
+fix: forward swapKind so limits can be calced accurately

--- a/modules/sor/lib/pathGraph/pathGraph.ts
+++ b/modules/sor/lib/pathGraph/pathGraph.ts
@@ -82,7 +82,6 @@ export class PathGraph {
         };
 
         // Calculate minimum limit threshold based on swap amount and ratio
-        // (5 COW * 0.5 * 100) / 100 = 2.5 COW
         const minLimitThreshold = (swapAmount.amount * BigInt(Math.floor(config.minSwapAmountRatio * 100))) / 100n;
 
         const tokenPaths = this.findAllValidTokenPaths({
@@ -513,9 +512,6 @@ export class PathGraph {
             try {
                 const path = this.expandTokenPathWithRanks({ tokenPath, ranks });
                 const limit = this.getLimitAmountSwapForPath(path, swapKind);
-
-                // limit 223212239396808561n
-                //       2500000000000000000n
                 if (limit >= minLimitThreshold) {
                     paths.push(path);
                     pathsRanks.push(ranks);

--- a/modules/sor/lib/pathGraph/pathGraph.ts
+++ b/modules/sor/lib/pathGraph/pathGraph.ts
@@ -61,11 +61,13 @@ export class PathGraph {
         tokenIn,
         tokenOut,
         swapAmount,
+        swapKind,
         graphTraversalConfig,
     }: {
         tokenIn: Token;
         tokenOut: Token;
         swapAmount: TokenAmount;
+        swapKind: SwapKind;
         graphTraversalConfig?: Partial<PathGraphTraversalConfig>;
     }): PathLocal[] {
         // apply defaults, allowing caller override whatever they'd like
@@ -80,6 +82,7 @@ export class PathGraph {
         };
 
         // Calculate minimum limit threshold based on swap amount and ratio
+        // (5 COW * 0.5 * 100) / 100 = 2.5 COW
         const minLimitThreshold = (swapAmount.amount * BigInt(Math.floor(config.minSwapAmountRatio * 100))) / 100n;
 
         const tokenPaths = this.findAllValidTokenPaths({
@@ -97,6 +100,7 @@ export class PathGraph {
         for (const tokenPath of tokenPaths) {
             const expandedPaths = this.expandTokenPathWithBestRanks({
                 tokenPath,
+                swapKind,
                 minLimitThreshold,
                 maxRanksPerSegment: config.maxRanksPerSegment,
                 approxPathsToReturn: config.approxPathsToReturn,
@@ -475,11 +479,13 @@ export class PathGraph {
      */
     private expandTokenPathWithBestRanks({
         tokenPath,
+        swapKind,
         minLimitThreshold,
         maxRanksPerSegment,
         approxPathsToReturn,
     }: {
         tokenPath: string[];
+        swapKind: SwapKind;
         minLimitThreshold: bigint;
         maxRanksPerSegment: number;
         approxPathsToReturn: number;
@@ -506,8 +512,10 @@ export class PathGraph {
 
             try {
                 const path = this.expandTokenPathWithRanks({ tokenPath, ranks });
-                const limit = this.getLimitAmountSwapForPath(path, SwapKind.GivenIn);
+                const limit = this.getLimitAmountSwapForPath(path, SwapKind.GivenOut);
 
+                // limit 223212239396808561n
+                //       2500000000000000000n
                 if (limit >= minLimitThreshold) {
                     paths.push(path);
                     pathsRanks.push(ranks);

--- a/modules/sor/lib/pathGraph/pathGraph.ts
+++ b/modules/sor/lib/pathGraph/pathGraph.ts
@@ -512,7 +512,7 @@ export class PathGraph {
 
             try {
                 const path = this.expandTokenPathWithRanks({ tokenPath, ranks });
-                const limit = this.getLimitAmountSwapForPath(path, SwapKind.GivenOut);
+                const limit = this.getLimitAmountSwapForPath(path, swapKind);
 
                 // limit 223212239396808561n
                 //       2500000000000000000n

--- a/modules/sor/lib/router.ts
+++ b/modules/sor/lib/router.ts
@@ -18,6 +18,7 @@ export class Router {
         tokenOut: Token,
         pools: BasePool[],
         swapAmount: TokenAmount,
+        swapKind: SwapKind,
         enableAddRemoveLiquidityPaths: boolean,
         graphTraversalConfig?: Partial<PathGraphTraversalConfig>,
     ): PathLocal[] {
@@ -27,6 +28,7 @@ export class Router {
             tokenIn,
             tokenOut,
             swapAmount,
+            swapKind,
             graphTraversalConfig,
         });
 

--- a/modules/sor/lib/sor.ts
+++ b/modules/sor/lib/sor.ts
@@ -151,6 +151,7 @@ export class SOR {
             tokenOut,
             basePools,
             checkedSwapAmount,
+            swapKind,
             protocolVersion === 3,
             swapOptions?.graphTraversalConfig,
         );

--- a/modules/sor/sor-debug.test.ts
+++ b/modules/sor/sor-debug.test.ts
@@ -7,9 +7,9 @@ import { Address, Swap, SwapInput, SwapKind } from '@balancer/sdk';
 import { formatUnits } from 'viem';
 
 describe('sor debugging', () => {
-    it('sor v2', async () => {
+    it.only('sor v2', async () => {
         const useProtocolVersion = 2;
-        const chain = Chain.MAINNET;
+        const chain = Chain.SONIC;
 
         const chainId = Object.keys(chainIdToChain).find((key) => chainIdToChain[key] === chain) as string;
         initRequestScopedContext();
@@ -18,43 +18,22 @@ describe('sor debugging', () => {
         // only do once before starting to debug
         // bun task sor-sync-v2 {chainId}
 
-        const swapType = 'EXACT_IN';
-        const swapKind: SwapKind = SwapKind.GivenIn;
-
-        /* const swaps = await sorService.getSorSwapPaths({
-            chain,
-            tokenIn: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', // USDC
-            tokenOut: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // USDC
-            swapType,
-            swapAmount: '100',
-            useProtocolVersion,
-            // callDataInput: {
-            //     receiver: '0xb5e6b895734409Df411a052195eb4EE7e40d8696',
-            //     sender: '0xb5e6b895734409Df411a052195eb4EE7e40d8696',
-            //     slippagePercentage: '0.1',
-            // },
-            poolIds: [
-                '0x79c58f70905f734641735bc61e45c19dd9ad60bc0000000000000000000004e7',
-                '0x63fc054159094583a27632361bd11c94c30e48c70002000000000000000006f7',
-            ],
-        }); */
+        const swapType = 'EXACT_OUT';
+        const swapKind: SwapKind = SwapKind.GivenOut;
 
         const swaps = await sorService.getSorSwapPaths({
             chain,
-            tokenIn: '0xdac17f958d2ee523a2206206994597c13d831ec7', // USDT
-            tokenOut: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH
+            tokenIn: '0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38', // wS
+            tokenOut: '0xe5da20f15420ad15de0fa650600afc998bbe3955', // stS
             swapType,
-            swapAmount: '100',
+            swapAmount: '100000',
             useProtocolVersion,
             // callDataInput: {
             //     receiver: '0xb5e6b895734409Df411a052195eb4EE7e40d8696',
             //     sender: '0xb5e6b895734409Df411a052195eb4EE7e40d8696',
             //     slippagePercentage: '0.1',
             // },
-            // poolIds: [
-            //     '0x79c58f70905f734641735bc61e45c19dd9ad60bc0000000000000000000004e7',
-            //     '0x63fc054159094583a27632361bd11c94c30e48c70002000000000000000006f7',
-            // ],
+            // poolIds: ['0x40d2cbc586dd8df50001cdba3f65cd4bbc32d596000200000000000000000154'],
         });
 
         console.log('protocol version', swaps.protocolVersion);
@@ -94,9 +73,9 @@ describe('sor debugging', () => {
         expect(ratio).toBeCloseTo(1, 3);
     }, 5000000);
 
-    it.only('sor v3', async () => {
+    it('sor v3', async () => {
         const useProtocolVersion = 3;
-        const chain = Chain.BASE;
+        const chain = Chain.MAINNET;
 
         const chainId = Object.keys(chainIdToChain).find((key) => chainIdToChain[key] === chain) as string;
         initRequestScopedContext();
@@ -104,17 +83,17 @@ describe('sor debugging', () => {
         // only do once before starting to debug
         // bun task sor-sync-v3 {chainId}
 
-        const swapType = 'EXACT_OUT';
-        const swapKind: SwapKind = SwapKind.GivenOut;
+        const swapType = 'EXACT_IN';
+        const swapKind: SwapKind = SwapKind.GivenIn;
 
         const swaps = await sorService.getSorSwapPaths({
             chain,
-            tokenIn: '0x4200000000000000000000000000000000000006', // WETH
-            tokenOut: '0xc694a91e6b071bf030a18bd3053a7fe09b6dae69', // COW
+            tokenIn: '0x40d16fc0246ad3160ccc09b8d0d3a2cd28ae6c2f', // GHO
+            tokenOut: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDC
             swapType,
-            swapAmount: '5',
+            swapAmount: '10',
             useProtocolVersion,
-            poolIds: ['0xff028c1ec4559d3aa2b0859aa582925b5cc28069'],
+            // poolIds: ['0x917d0464dd2e335bf14000c63d65def3c8bb1025'],
         });
 
         console.log(swaps.returnAmount);
@@ -122,7 +101,7 @@ describe('sor debugging', () => {
             console.log(`path ${i}`, path.pools);
         });
 
-        // Perform sanity check agaist on-chain query
+        // Perform sanity check against on-chain query
 
         const swapInput: SwapInput = {
             chainId: Number(chainId),

--- a/modules/sor/sor-debug.test.ts
+++ b/modules/sor/sor-debug.test.ts
@@ -7,9 +7,9 @@ import { Address, Swap, SwapInput, SwapKind } from '@balancer/sdk';
 import { formatUnits } from 'viem';
 
 describe('sor debugging', () => {
-    it.only('sor v2', async () => {
+    it('sor v2', async () => {
         const useProtocolVersion = 2;
-        const chain = Chain.SONIC;
+        const chain = Chain.MAINNET;
 
         const chainId = Object.keys(chainIdToChain).find((key) => chainIdToChain[key] === chain) as string;
         initRequestScopedContext();
@@ -18,22 +18,43 @@ describe('sor debugging', () => {
         // only do once before starting to debug
         // bun task sor-sync-v2 {chainId}
 
-        const swapType = 'EXACT_OUT';
-        const swapKind: SwapKind = SwapKind.GivenOut;
+        const swapType = 'EXACT_IN';
+        const swapKind: SwapKind = SwapKind.GivenIn;
 
-        const swaps = await sorService.getSorSwapPaths({
+        /* const swaps = await sorService.getSorSwapPaths({
             chain,
-            tokenIn: '0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38', // wS
-            tokenOut: '0xe5da20f15420ad15de0fa650600afc998bbe3955', // stS
+            tokenIn: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', // USDC
+            tokenOut: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // USDC
             swapType,
-            swapAmount: '100000',
+            swapAmount: '100',
             useProtocolVersion,
             // callDataInput: {
             //     receiver: '0xb5e6b895734409Df411a052195eb4EE7e40d8696',
             //     sender: '0xb5e6b895734409Df411a052195eb4EE7e40d8696',
             //     slippagePercentage: '0.1',
             // },
-            // poolIds: ['0x40d2cbc586dd8df50001cdba3f65cd4bbc32d596000200000000000000000154'],
+            poolIds: [
+                '0x79c58f70905f734641735bc61e45c19dd9ad60bc0000000000000000000004e7',
+                '0x63fc054159094583a27632361bd11c94c30e48c70002000000000000000006f7',
+            ],
+        }); */
+
+        const swaps = await sorService.getSorSwapPaths({
+            chain,
+            tokenIn: '0xdac17f958d2ee523a2206206994597c13d831ec7', // USDT
+            tokenOut: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH
+            swapType,
+            swapAmount: '100',
+            useProtocolVersion,
+            // callDataInput: {
+            //     receiver: '0xb5e6b895734409Df411a052195eb4EE7e40d8696',
+            //     sender: '0xb5e6b895734409Df411a052195eb4EE7e40d8696',
+            //     slippagePercentage: '0.1',
+            // },
+            // poolIds: [
+            //     '0x79c58f70905f734641735bc61e45c19dd9ad60bc0000000000000000000004e7',
+            //     '0x63fc054159094583a27632361bd11c94c30e48c70002000000000000000006f7',
+            // ],
         });
 
         console.log('protocol version', swaps.protocolVersion);
@@ -73,9 +94,9 @@ describe('sor debugging', () => {
         expect(ratio).toBeCloseTo(1, 3);
     }, 5000000);
 
-    it('sor v3', async () => {
+    it.only('sor v3', async () => {
         const useProtocolVersion = 3;
-        const chain = Chain.MAINNET;
+        const chain = Chain.BASE;
 
         const chainId = Object.keys(chainIdToChain).find((key) => chainIdToChain[key] === chain) as string;
         initRequestScopedContext();
@@ -83,17 +104,17 @@ describe('sor debugging', () => {
         // only do once before starting to debug
         // bun task sor-sync-v3 {chainId}
 
-        const swapType = 'EXACT_IN';
-        const swapKind: SwapKind = SwapKind.GivenIn;
+        const swapType = 'EXACT_OUT';
+        const swapKind: SwapKind = SwapKind.GivenOut;
 
         const swaps = await sorService.getSorSwapPaths({
             chain,
-            tokenIn: '0x40d16fc0246ad3160ccc09b8d0d3a2cd28ae6c2f', // GHO
-            tokenOut: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDC
+            tokenIn: '0x4200000000000000000000000000000000000006', // WETH
+            tokenOut: '0xc694a91e6b071bf030a18bd3053a7fe09b6dae69', // COW
             swapType,
-            swapAmount: '10',
+            swapAmount: '5',
             useProtocolVersion,
-            // poolIds: ['0x917d0464dd2e335bf14000c63d65def3c8bb1025'],
+            poolIds: ['0xff028c1ec4559d3aa2b0859aa582925b5cc28069'],
         });
 
         console.log(swaps.returnAmount);
@@ -101,7 +122,7 @@ describe('sor debugging', () => {
             console.log(`path ${i}`, path.pools);
         });
 
-        // Perform sanity check against on-chain query
+        // Perform sanity check agaist on-chain query
 
         const swapInput: SwapInput = {
             chainId: Number(chainId),

--- a/test/testData/config.json
+++ b/test/testData/config.json
@@ -366,6 +366,29 @@
             }
         },
         {
+            "testName": "Path-ReClamm-In-Range-Cow-WETH",
+            "chainId": "8453",
+            "blockNumber": "32929295",
+            "swapPathInput": {
+                "swapKind": 1,
+                "paths": [
+                    {
+                        "amountRaw": "5000000000000000000",
+                        "tokens": [
+                            "0x4200000000000000000000000000000000000006",
+                            "0xc694a91e6b071bf030a18bd3053a7fe09b6dae69"
+                        ],
+                        "pools": [
+                            {
+                                "poolAddress": "0xff028c1ec4559d3aa2b0859aa582925b5cc28069",
+                                "poolType": "RECLAMM"
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+        {
             "testName": "Path-Buffer",
             "chainId": "1",
             "blockNumber": "21671845",

--- a/test/testData/read/8453-32929295-Path-ReClamm-In-Range-Cow-WETH.json
+++ b/test/testData/read/8453-32929295-Path-ReClamm-In-Range-Cow-WETH.json
@@ -1,0 +1,64 @@
+{
+    "test": {
+        "chainId": "8453",
+        "blockNumber": "32929295"
+    },
+    "swapPath": {
+        "swapKind": 1,
+        "paths": [
+            {
+                "amountRaw": "5000000000000000000",
+                "tokens": [
+                    "0x4200000000000000000000000000000000000006",
+                    "0xc694a91e6b071bf030a18bd3053a7fe09b6dae69"
+                ],
+                "pools": [
+                    {
+                        "poolAddress": "0xff028c1ec4559d3aa2b0859aa582925b5cc28069",
+                        "poolType": "RECLAMM"
+                    }
+                ],
+                "calculatedAmountRaw": "708793406598661"
+            }
+        ]
+    },
+    "pools": [
+        {
+            "chainId": "8453",
+            "blockNumber": "32929295",
+            "poolType": "RECLAMM",
+            "poolAddress": "0xff028c1ec4559d3aa2b0859aa582925b5cc28069",
+            "tokens": [
+                "0x4200000000000000000000000000000000000006",
+                "0xc694a91e6b071bF030A18BD3053A7fE09B6DaE69"
+            ],
+            "scalingFactors": [
+                "1",
+                "1"
+            ],
+            "aggregateSwapFee": "500000000000000000",
+            "swapFee": "3000000000000000",
+            "totalSupply": "7777617334025436808",
+            "balancesLiveScaled18": [
+                "236826758525922389",
+                "1007417842444821029312"
+            ],
+            "tokenRates": [
+                "1000000000000000000",
+                "1000000000000000000"
+            ],
+            "lastTimestamp": "1752641825",
+            "lastVirtualBalances": [
+                "505530820430926044",
+                "4250109523667556437684"
+            ],
+            "dailyPriceShiftBase": "999999197747274347",
+            "centerednessMargin": "500000000000000000",
+            "startFourthRootPriceRatio": "1347575479745574070",
+            "endFourthRootPriceRatio": "1347575479745574070",
+            "priceRatioUpdateStartTime": "1752160515",
+            "priceRatioUpdateEndTime": "1752160515",
+            "currentTimestamp": "1752647937"
+        }
+    ]
+}


### PR DESCRIPTION
Closes: https://github.com/balancer/backend/pull/2212

This PR fixes an issue where the swap kind was not being properly forwarded through the routing system, causing inaccurate limit calculations. The fix ensures that the swapKind parameter is passed down through the call chain from the SOR entry point to the path expansion logic where limits are calculated.

Threads swapKind parameter through Router and PathGraph classes
Updates limit calculation to use the actual swap kind instead of hardcoded SwapKind.GivenIn
Adds test data for a new ReClamm pool swap scenario