### PR TITLE
SOR path finding optimisations

### DIFF
--- a/modules/sor/lib/pathGraph/optimisation.md
+++ b/modules/sor/lib/pathGraph/optimisation.md
@@ -1,0 +1,281 @@
+Here’s a drop-in refactor that makes token-path search and rank expansion much faster, without changing your public API. It removes recursion, minimizes array copies, incrementally tracks constraints, and uses a beam-search to prune rank combinations early using cheap per-edge limits.
+
+What you get
+
+-   Non-recursive, allocation-light token-path search (iterative DFS with incremental constraints).
+-   Early bounding using approxPathsToReturn (as your docs suggest).
+-   Beam search for rank expansion:
+    -   Precomputes and caches per-edge swap limits (cheap optimistic bound).
+    -   Prunes combinations aggressively before running expensive getLimitAmountSwapForPath.
+    -   Returns the top candidates meeting the minLimitThreshold.
+
+Code changes
+
+1. Add a small cache for per-edge limits (used by the new beam search).
+2. Replace findAllValidTokenPaths with an iterative search that’s faster and honors approxPathsToReturn.
+3. Replace expandTokenPathWithBestRanks with a beam search that uses cached, optimistic bounds.
+
+You can paste these changes into your class. Comments explain the logic.
+
+```ts
+// Add this private cache in the class
+private edgeLimitCache: Map<string, bigint> = new Map();
+
+// In buildGraph() reset the cache so it doesn't leak across builds
+public buildGraph({
+    pools,
+    maxPathsPerTokenPair = DEFAULT_MAX_PATHS_PER_TOKEN_PAIR,
+    enableAddRemoveLiquidityPaths,
+}: {
+    pools: BasePool[];
+    maxPathsPerTokenPair?: number;
+    enableAddRemoveLiquidityPaths: boolean;
+}) {
+    this.poolAddressMap = new Map();
+    this.nodes = new Map();
+    this.edges = new Map();
+    this.edgeLimitCache = new Map(); // <-- reset cache
+    this.maxPathsPerTokenPair = maxPathsPerTokenPair;
+
+    this.buildPoolAddressMap(pools);
+    this.addAllTokensAsGraphNodes({ pools, enableAddRemoveLiquidityPaths });
+    this.addTokenPairsAsGraphEdges({ pools, maxPathsPerTokenPair, enableAddRemoveLiquidityPaths });
+}
+
+// Small helper for cached per-edge limit (optimistic bound)
+private getEdgeLimitCached(edge: PathGraphEdgeData, swapKind: SwapKind): bigint {
+    const key = `${edge.pool.id}|${edge.tokenIn}|${edge.tokenOut}|${swapKind}`;
+    let v = this.edgeLimitCache.get(key);
+    if (v === undefined) {
+        v = edge.pool.getLimitAmountSwap(edge.tokenIn, edge.tokenOut, swapKind);
+        this.edgeLimitCache.set(key, v);
+    }
+    return v;
+}
+```
+
+Replace findAllValidTokenPaths with this (iterative, allocation-light)
+
+```ts
+private findAllValidTokenPaths(args: {
+    token: string;
+    tokenIn: string;
+    tokenOut: string;
+    tokenPath: string[]; // unused in refactor; we always start from tokenIn
+    config: PathGraphTraversalConfig;
+}): string[][] {
+    const { tokenIn, tokenOut, config } = args;
+
+    const results: string[][] = [];
+    if (tokenIn === tokenOut) return [[tokenIn]];
+
+    // State tracked incrementally to avoid rescanning the whole path
+    const path: string[] = [tokenIn];
+    const visited = new Set<string>([tokenIn]);
+
+    // We use an iterative DFS (non-recursive) for performance.
+    // Ordering doesn’t matter since caller sorts by length later.
+    type Frame = {
+        token: string;
+        iter: IterableIterator<[string, PathGraphEdgeData[]]>;
+        isBoosted: boolean;
+        numStandardHopTokens: number;
+    };
+
+    const startNeighbors = this.edges.get(tokenIn)?.entries() ?? new Map<string, PathGraphEdgeData[]>().entries();
+    let current: Frame = {
+        token: tokenIn,
+        iter: startNeighbors,
+        isBoosted: this.poolAddressMap.has(tokenIn),
+        numStandardHopTokens: 0,
+    };
+    const stack: Frame[] = [];
+
+    // Respect the "approxPathsToReturn" as an upper bound (per docs).
+    const maxTokenPaths = Math.max(1, config.approxPathsToReturn);
+
+    outer: while (true) {
+        const step = current.iter.next();
+
+        if (step.done) {
+            // backtrack
+            if (stack.length === 0) break;
+            const lastNode = path.pop()!;
+            visited.delete(lastNode);
+            current = stack.pop()!;
+            continue;
+        }
+
+        const neighbor = step.value[0];
+
+        // No revisiting the same token
+        if (visited.has(neighbor)) continue;
+
+        const nextDepth = path.length + 1;
+        if (nextDepth > config.maxDepth) continue;
+
+        const neighborIsPhantom = this.poolAddressMap.has(neighbor);
+        const nextIsBoosted = current.isBoosted || neighborIsPhantom;
+
+        // Count hop tokens excluding endpoints
+        const isHopToken = neighbor !== tokenIn && neighbor !== tokenOut;
+        const nextNumStandardHopTokens = current.numStandardHopTokens + (isHopToken && !neighborIsPhantom ? 1 : 0);
+
+        // Prune using the same rules as isValidTokenPath but incrementally
+        if (nextIsBoosted && nextNumStandardHopTokens > config.maxNonBoostedHopTokensInBoostedPath) continue;
+
+        if (
+            nextDepth > config.maxNonBoostedPathDepth &&
+            nextNumStandardHopTokens > config.maxNonBoostedHopTokensInBoostedPath
+        ) {
+            continue;
+        }
+
+        if (neighbor === tokenOut) {
+            // Complete path checks
+            if (!nextIsBoosted && nextDepth > config.maxNonBoostedPathDepth) continue;
+            results.push([...path, neighbor]);
+            if (results.length >= maxTokenPaths) break outer;
+            continue;
+        }
+
+        // Go deeper
+        path.push(neighbor);
+        visited.add(neighbor);
+
+        // Save current frame and descend
+        stack.push(current);
+        current = {
+            token: neighbor,
+            iter: this.edges.get(neighbor)?.entries() ?? new Map<string, PathGraphEdgeData[]>().entries(),
+            isBoosted: nextIsBoosted,
+            numStandardHopTokens: nextNumStandardHopTokens,
+        };
+    }
+
+    return results;
+}
+```
+
+Replace expandTokenPathWithBestRanks with a fast beam search
+
+```ts
+/**
+ * Beam-search over ranks per segment.
+ * - Precompute a cheap optimistic bound per edge using getLimitAmountSwap (cached).
+ * - Expand only top candidates by that bound before evaluating expensive full-path limit.
+ * - Keeps at most approxPathsToReturn candidates throughout.
+ */
+private expandTokenPathWithBestRanks({
+    tokenPath,
+    swapKind,
+    minLimitThreshold,
+    maxRanksPerSegment,
+    approxPathsToReturn,
+}: {
+    tokenPath: string[];
+    swapKind: SwapKind;
+    minLimitThreshold: bigint;
+    maxRanksPerSegment: number;
+    approxPathsToReturn: number;
+}): PathGraphEdgeData[][] {
+    const segmentCount = tokenPath.length - 1;
+    if (segmentCount <= 0) return [];
+
+    // Gather candidate edges per segment (already sorted by normalizedLiquidity desc).
+    const perSegmentEdges: PathGraphEdgeData[][] = new Array(segmentCount);
+    for (let i = 0; i < segmentCount; i++) {
+        const edges = this.edges.get(tokenPath[i])?.get(tokenPath[i + 1]) ?? [];
+        if (edges.length === 0) return []; // path cannot be built
+        // Limit choices per segment
+        perSegmentEdges[i] = edges.slice(0, Math.min(edges.length, maxRanksPerSegment, this.maxPathsPerTokenPair));
+    }
+
+    // Precompute optimistic bound per candidate edge (cached)
+    const perSegmentEdgeBounds: bigint[][] = perSegmentEdges.map((edges) =>
+        edges.map((e) => this.getEdgeLimitCached(e, swapKind)),
+    );
+
+    // Beam search: keep only the top K partial combos by optimistic bound
+    type Partial = { ranks: number[]; bound: bigint };
+    let partials: Partial[] = [{ ranks: [], bound: 0n }]; // bound will be set on first expansion
+
+    // Make the beam wider than the final number to ensure diversity
+    const beamWidth = Math.max(approxPathsToReturn * 3, approxPathsToReturn);
+
+    for (let seg = 0; seg < segmentCount; seg++) {
+        const edges = perSegmentEdges[seg];
+        const bounds = perSegmentEdgeBounds[seg];
+        const next: Partial[] = [];
+
+        for (const p of partials) {
+            for (let r = 0; r < edges.length; r++) {
+                // optimistic bound for extended partial is min of previous bound and this edge bound
+                const newBound = p.ranks.length === 0 ? bounds[r] : bounds[r] < p.bound ? bounds[r] : p.bound;
+
+                // Early prune by minLimitThreshold
+                if (newBound < minLimitThreshold) continue;
+
+                const ranks = p.ranks.length === 0 ? [r] : [...p.ranks, r];
+                next.push({ ranks, bound: newBound });
+            }
+        }
+
+        if (next.length === 0) return [];
+
+        // Keep only the best by optimistic bound (desc)
+        next.sort((a, b) => (a.bound < b.bound ? 1 : -1));
+        partials = next.slice(0, beamWidth);
+    }
+
+    // Evaluate real limits only for the finalists and filter by threshold
+    // This is the expensive part; we limited it by beamWidth.
+    const pathsWithRealLimit: { path: PathGraphEdgeData[]; limit: bigint }[] = [];
+    const seenCombos = new Set<string>();
+
+    for (const p of partials) {
+        const key = p.ranks.join(',');
+        if (seenCombos.has(key)) continue;
+        seenCombos.add(key);
+
+        try {
+            const path = this.expandTokenPathWithRanks({ tokenPath, ranks: p.ranks });
+            const limit = this.getLimitAmountSwapForPath(path, swapKind);
+            if (limit >= minLimitThreshold) {
+                pathsWithRealLimit.push({ path, limit });
+                if (pathsWithRealLimit.length >= approxPathsToReturn) {
+                    // We can stop early if we already have enough
+                    // candidates meeting the threshold.
+                    // We will still sort below for determinism.
+                    // This keeps CPU in check on large graphs.
+                    break;
+                }
+            }
+        } catch {
+            // Missing rank or edge; skip
+            continue;
+        }
+    }
+
+    if (pathsWithRealLimit.length === 0) return [];
+
+    // Return top approxPathsToReturn by real limit
+    pathsWithRealLimit.sort((a, b) => (a.limit < b.limit ? 1 : -1));
+    return pathsWithRealLimit.slice(0, approxPathsToReturn).map((x) => x.path);
+}
+```
+
+Why this is faster
+
+-   No recursion or repeated array copies in token-path search; we push/pop on a single shared path and visited set.
+-   Incremental constraint tracking avoids O(len(path)) scans on each step.
+-   Early stop based on approxPathsToReturn (as your comments suggest) keeps the search bounded.
+-   Beam search on ranks uses cached per-edge limits to prune aggressively before running the expensive full-path limit calculation.
+-   At most approxPathsToReturn full getLimitAmountSwapForPath evaluations per token path, instead of exploring all rank combinations.
+
+Optional micro-optimizations
+
+-   If you want even less GC pressure, switch visited to a bitset by indexing tokens, but that’s a larger refactor (you’d assign an integer index to each token once in buildGraph and use a Uint8Array or BigInt bitmask).
+-   You can nudge beamWidth up or down depending on how much diversity you want versus speed.
+
+If you want, I can wire a small benchmark harness around getCandidatePaths to measure the speedups against your pool sizes and typical configurations.

--- a/modules/sor/lib/pathGraph/pathGraph-beam.test.ts
+++ b/modules/sor/lib/pathGraph/pathGraph-beam.test.ts
@@ -1,0 +1,780 @@
+import { PathGraphBeam } from './pathGraph-beam';
+import { BasePool } from '../poolsV2/basePool';
+import { Token, TokenAmount, SwapKind } from '@balancer/sdk';
+import { describe, test, expect, beforeEach } from 'bun:test';
+
+const baseConfig = {
+    maxDepth: 6,
+    maxNonBoostedPathDepth: 3,
+    maxNonBoostedHopTokensInBoostedPath: 2,
+    maxBuffersInPath: 5,
+    approxPathsToReturn: 20,
+    maxRanksPerSegment: 2,
+    minSwapAmountRatio: 0.5,
+    maxTokenPaths: 50,
+};
+
+function createMockPool(id: string, tokens: Token[], opts: Partial<BasePool> = {}): BasePool {
+    return {
+        id,
+        address: id,
+        poolType: opts.poolType ?? 'Weighted',
+        tokens: tokens.map((t) => ({ token: t })),
+        getNormalizedLiquidity: opts.getNormalizedLiquidity ?? (() => 100n),
+        getLimitAmountSwap: opts.getLimitAmountSwap ?? (() => 1_000_000n),
+        swapGivenOut: opts.swapGivenOut ?? ((_in: Token, _out: Token, amt: TokenAmount) => amt),
+        ...opts,
+    } as unknown as BasePool;
+}
+
+describe('PathGraphBeam search algorithms', () => {
+    const tokenA = new Token(1, '0xa', 18);
+    const tokenB = new Token(1, '0xb', 18);
+    const tokenC = new Token(1, '0xc', 18);
+    const tokenD = new Token(1, '0xd', 18);
+
+    let pools: BasePool[];
+    let graph: PathGraphBeam;
+
+    beforeEach(() => {
+        pools = [
+            createMockPool('p1', [tokenA, tokenB]),
+            createMockPool('p2', [tokenB, tokenC]),
+            createMockPool('p3', [tokenC, tokenD]),
+            createMockPool('p4', [tokenA, tokenD], { poolType: 'Buffer' }),
+        ];
+        graph = new PathGraphBeam();
+        graph.buildGraph({ pools, enableAddRemoveLiquidityPaths: false });
+    });
+
+    test('finds direct path', () => {
+        const paths = graph['findAllValidTokenPaths']({
+            tokenIn: tokenA.wrapped,
+            tokenOut: tokenB.wrapped,
+            config: { ...baseConfig },
+        });
+
+        expect(paths).toContainEqual([tokenA.wrapped, tokenB.wrapped]);
+    });
+
+    test('avoids revisiting tokens (no cycles)', () => {
+        // path A -> B -> A -> B should not appear
+        const paths = graph['findAllValidTokenPaths']({
+            tokenIn: tokenA.wrapped,
+            tokenOut: tokenC.wrapped,
+            config: { ...baseConfig },
+        });
+
+        for (const path of paths) {
+            const visited = new Set(path);
+            expect(visited.size).toBe(path.length); // ensures no duplicate token
+        }
+    });
+
+    test('respects maxDepth limit', () => {
+        const paths = graph['findAllValidTokenPaths']({
+            tokenIn: tokenA.wrapped,
+            tokenOut: tokenD.wrapped,
+            config: { ...baseConfig, maxDepth: 2 },
+        });
+
+        // Only A -> D (buffer pool) should be valid, not A -> B -> C -> D
+        expect(paths).toContainEqual([tokenA.wrapped, tokenD.wrapped]);
+        expect(paths).not.toContainEqual([tokenA.wrapped, tokenB.wrapped, tokenC.wrapped, tokenD.wrapped]);
+    });
+
+    test('expandTokenPathWithBestRanks keeps at least rank-0 path', () => {
+        const path = [tokenA.wrapped, tokenB.wrapped, tokenC.wrapped];
+        const result = graph['expandTokenPathWithBestRanks']({
+            tokenPath: path,
+            swapKind: SwapKind.GivenIn,
+            minLimitThreshold: 1n,
+            approxPathsToReturn: 5,
+            config: { ...baseConfig },
+        });
+
+        expect(result.length).toBeGreaterThan(0);
+        // path[0] should be p1 rank-0, path[1] should be p2 rank-0
+        result.forEach((segments) => {
+            expect(segments.every((s) => !!s.pool)).toBe(true);
+        });
+    });
+
+    test('findAllValidTokenPaths traversal order is breadth-first', () => {
+        const g = new PathGraphBeam();
+        const localPools = [
+            createMockPool('pAB', [tokenA, tokenB]),
+            createMockPool('pAC', [tokenA, tokenC]),
+            createMockPool('pBD', [tokenB, tokenD]),
+            createMockPool('pCD', [tokenC, tokenD]),
+        ];
+        g.buildGraph({ pools: localPools, enableAddRemoveLiquidityPaths: false });
+
+        const paths = g['findAllValidTokenPaths']({
+            tokenIn: tokenA.wrapped,
+            tokenOut: tokenD.wrapped,
+            config: { ...baseConfig },
+        });
+
+        // Expect BFS-like order
+        expect(paths[0]).toEqual([tokenA.wrapped, tokenB.wrapped, tokenD.wrapped]);
+        expect(paths[1]).toEqual([tokenA.wrapped, tokenC.wrapped, tokenD.wrapped]);
+    });
+
+    test('isValidPath rejects paths that reuse the same pool within a single path', () => {
+        const g = new PathGraphBeam();
+        const tri = createMockPool('pTri', [tokenA, tokenB, tokenC]);
+        g.buildGraph({ pools: [tri], enableAddRemoveLiquidityPaths: false });
+
+        const paths = g.getCandidatePaths({
+            tokenIn: tokenA,
+            tokenOut: tokenC,
+            swapAmount: TokenAmount.fromRawAmount(tokenA, 1_000n),
+            swapKind: SwapKind.GivenIn,
+            graphTraversalConfig: { ...baseConfig },
+        });
+
+        let foundPathWithReusedPool = false;
+        for (const path of paths) {
+            const poolIds = path.pools.map((p) => p.id);
+            if (new Set(poolIds).size !== poolIds.length) {
+                foundPathWithReusedPool = true;
+                break;
+            }
+        }
+
+        expect(foundPathWithReusedPool).toBe(false);
+    });
+
+    test('getCandidatePaths respects poolIdsToInclude whitelist (filters mixed paths)', () => {
+        const g = new PathGraphBeam();
+        const p1 = createMockPool('p1', [tokenA, tokenB]);
+        const p2 = createMockPool('p2', [tokenB, tokenC]);
+        g.buildGraph({ pools: [p1, p2], enableAddRemoveLiquidityPaths: false });
+
+        const paths = g.getCandidatePaths({
+            tokenIn: tokenA,
+            tokenOut: tokenC,
+            swapAmount: TokenAmount.fromRawAmount(tokenA, 1_000n),
+            swapKind: SwapKind.GivenIn,
+            graphTraversalConfig: {
+                ...baseConfig,
+                poolIdsToInclude: ['p2'], // p1 not allowed
+            },
+        });
+
+        expect(paths.length).toBe(0);
+    });
+
+    test('maxBuffersInPath is enforced', () => {
+        const g = new PathGraphBeam();
+        const buf1 = createMockPool('buf1', [tokenA, tokenB], { poolType: 'Buffer' });
+        const buf2 = createMockPool('buf2', [tokenB, tokenC], { poolType: 'Buffer' });
+        g.buildGraph({ pools: [buf1, buf2], enableAddRemoveLiquidityPaths: false });
+
+        const paths = g.getCandidatePaths({
+            tokenIn: tokenA,
+            tokenOut: tokenC,
+            swapAmount: TokenAmount.fromRawAmount(tokenA, 1_000n),
+            swapKind: SwapKind.GivenIn,
+            graphTraversalConfig: {
+                ...baseConfig,
+                maxBuffersInPath: 1, // path has 2 buffers -> invalid
+            },
+        });
+
+        expect(paths.length).toBe(0);
+    });
+
+    test('respects maxPathsPerTokenPair (keeps only top-K ranked edges for a pair)', () => {
+        const g = new PathGraphBeam();
+
+        const pAB1 = createMockPool('pAB1', [tokenA, tokenB], { getNormalizedLiquidity: () => 300n });
+        const pAB2 = createMockPool('pAB2', [tokenA, tokenB], { getNormalizedLiquidity: () => 200n });
+        const pAB3 = createMockPool('pAB3', [tokenA, tokenB], { getNormalizedLiquidity: () => 100n });
+
+        g.buildGraph({
+            pools: [pAB1, pAB2, pAB3],
+            enableAddRemoveLiquidityPaths: false,
+            maxPathsPerTokenPair: 2,
+        });
+
+        const result = g['expandTokenPathWithBestRanks']({
+            tokenPath: [tokenA.wrapped, tokenB.wrapped],
+            swapKind: SwapKind.GivenIn,
+            minLimitThreshold: 1n,
+            approxPathsToReturn: 10,
+            config: { ...baseConfig },
+        });
+
+        const poolsUsed = new Set<string>(result.map((segments) => segments[0].pool.id));
+
+        expect(result.length).toBeLessThanOrEqual(2);
+        expect(poolsUsed.has('pAB1')).toBe(true);
+        expect(poolsUsed.has('pAB2')).toBe(true);
+        expect(poolsUsed.has('pAB3')).toBe(false); // trimmed by top-K
+    });
+
+    test('expandTokenPathWithBestRanks is resilient even when ranks exceed available edges', () => {
+        const g = new PathGraphBeam();
+        const pAB = createMockPool('pAB', [tokenA, tokenB]);
+        g.buildGraph({ pools: [pAB], enableAddRemoveLiquidityPaths: false });
+
+        const result = g['expandTokenPathWithBestRanks']({
+            tokenPath: [tokenA.wrapped, tokenB.wrapped],
+            swapKind: SwapKind.GivenIn,
+            minLimitThreshold: 1n,
+            approxPathsToReturn: 10,
+            config: { ...baseConfig, maxRanksPerSegment: 10 },
+        });
+
+        expect(result.length).toBe(1);
+        expect(result[0][0].pool.id as string).toBe('pAB');
+    });
+
+    test('minSwapAmountRatio quantization can yield zero threshold for tiny ratios', () => {
+        const g = new PathGraphBeam();
+        const pAB = createMockPool('pAB', [tokenA, tokenB], {
+            getLimitAmountSwap: () => 5n,
+        });
+        g.buildGraph({ pools: [pAB], enableAddRemoveLiquidityPaths: false });
+
+        const tinyRatio = 0.009; // floor(0.9)/100 = 0 => zero threshold with current logic
+        const paths = g.getCandidatePaths({
+            tokenIn: tokenA,
+            tokenOut: tokenB,
+            swapAmount: TokenAmount.fromRawAmount(tokenA, 100n),
+            swapKind: SwapKind.GivenIn,
+            graphTraversalConfig: { ...baseConfig, minSwapAmountRatio: tinyRatio },
+        });
+
+        expect(paths.length).toBeGreaterThan(0);
+    });
+
+    test('reuses a pool across selected paths', () => {
+        const g = new PathGraphBeam();
+        const pAB = createMockPool('pAB', [tokenA, tokenB]);
+        const pAC = createMockPool('pAC', [tokenA, tokenC]);
+        const pShared = createMockPool('pShared', [tokenB, tokenC, tokenD]);
+
+        g.buildGraph({ pools: [pAB, pAC, pShared], enableAddRemoveLiquidityPaths: false });
+
+        const paths = g.getCandidatePaths({
+            tokenIn: tokenA,
+            tokenOut: tokenD,
+            swapAmount: TokenAmount.fromRawAmount(tokenA, 10_000n),
+            swapKind: SwapKind.GivenIn,
+            graphTraversalConfig: { ...baseConfig },
+        });
+
+        expect(paths.length).toBe(2);
+    });
+
+    test('enforces maxTokenPaths limit during token path discovery', () => {
+        const g = new PathGraphBeam();
+
+        // Create a hub-and-spoke topology to generate many paths
+        const hub = new Token(1, '0xhub', 18);
+        const spokes = Array.from({ length: 10 }, (_, i) => new Token(1, `0xspoke${i}`, 18));
+        const target = new Token(1, '0xtarget', 18);
+
+        const hubPools = spokes.map((spoke, i) => createMockPool(`hub${i}`, [hub, spoke]));
+        const spokePools = spokes.map((spoke, i) => createMockPool(`spoke${i}`, [spoke, target]));
+
+        g.buildGraph({ pools: [...hubPools, ...spokePools], enableAddRemoveLiquidityPaths: false });
+
+        // This should generate 10 possible token paths: hub -> spoke[i] -> target
+        const paths = g['findAllValidTokenPaths']({
+            tokenIn: hub.wrapped,
+            tokenOut: target.wrapped,
+            config: { ...baseConfig, maxTokenPaths: 5 }, // limit to 5
+        });
+
+        expect(paths.length).toBe(5); // Should be capped at maxTokenPaths
+    });
+
+    test('handles SwapKind.GivenOut correctly', () => {
+        const g = new PathGraphBeam();
+        const pAB = createMockPool('pAB', [tokenA, tokenB], {
+            getLimitAmountSwap: (tokenIn: Token, tokenOut: Token, swapKind: SwapKind) => {
+                // Return different limits based on swap kind
+                return swapKind === SwapKind.GivenOut ? 500n : 1000n;
+            },
+        });
+        g.buildGraph({ pools: [pAB], enableAddRemoveLiquidityPaths: false });
+
+        const pathsGivenIn = g.getCandidatePaths({
+            tokenIn: tokenA,
+            tokenOut: tokenB,
+            swapAmount: TokenAmount.fromRawAmount(tokenA, 1000n),
+            swapKind: SwapKind.GivenIn,
+            graphTraversalConfig: { ...baseConfig, minSwapAmountRatio: 0.8 }, // requires 800n
+        });
+
+        const pathsGivenOut = g.getCandidatePaths({
+            tokenIn: tokenA,
+            tokenOut: tokenB,
+            swapAmount: TokenAmount.fromRawAmount(tokenB, 1000n),
+            swapKind: SwapKind.GivenOut,
+            graphTraversalConfig: { ...baseConfig, minSwapAmountRatio: 0.8 }, // requires 800n
+        });
+
+        expect(pathsGivenIn.length).toBe(1); // 1000n >= 800n threshold
+        expect(pathsGivenOut.length).toBe(0); // 500n < 800n threshold
+    });
+
+    test('filters paths based on limit amount calculations', () => {
+        const g = new PathGraphBeam();
+
+        const highLiquidityPool = createMockPool('highLiq', [tokenA, tokenB], {
+            getNormalizedLiquidity: () => 1000n,
+            getLimitAmountSwap: () => 2000n, // High limit
+        });
+
+        const lowLiquidityPool = createMockPool('lowLiq', [tokenA, tokenB], {
+            getNormalizedLiquidity: () => 999n, // Slightly lower NL so it's ranked second
+            getLimitAmountSwap: () => 100n, // Low limit
+        });
+
+        g.buildGraph({
+            pools: [highLiquidityPool, lowLiquidityPool],
+            enableAddRemoveLiquidityPaths: false,
+            maxPathsPerTokenPair: 2,
+        });
+
+        const paths = g.getCandidatePaths({
+            tokenIn: tokenA,
+            tokenOut: tokenB,
+            swapAmount: TokenAmount.fromRawAmount(tokenA, 1000n),
+            swapKind: SwapKind.GivenIn,
+            graphTraversalConfig: {
+                ...baseConfig,
+                minSwapAmountRatio: 0.15, // requires 150n minimum
+                approxPathsToReturn: 10,
+            },
+        });
+
+        // Only the high liquidity pool should pass the limit filter
+        expect(paths.length).toBe(1);
+        expect(paths[0].pools[0].id as string).toBe('highLiq');
+    });
+
+    test('beam search considers bottleneck liquidity across path segments', () => {
+        const g = new PathGraphBeam();
+
+        // Create a scenario to test beam search behavior
+        const midToken = new Token(1, '0xmid', 18);
+
+        // Path 1: A -> mid -> D (high first hop, low second hop)
+        const highFirst = createMockPool('highFirst', [tokenA, midToken], {
+            getNormalizedLiquidity: () => 1000n,
+        });
+        const lowSecond = createMockPool('lowSecond', [midToken, tokenD], {
+            getNormalizedLiquidity: () => 200n,
+        });
+
+        // Path 2: A -> mid -> D (medium first hop, high second hop)
+        const medFirst = createMockPool('medFirst', [tokenA, midToken], {
+            getNormalizedLiquidity: () => 800n,
+        });
+        const highSecond = createMockPool('highSecond', [midToken, tokenD], {
+            getNormalizedLiquidity: () => 900n,
+        });
+
+        g.buildGraph({
+            pools: [highFirst, lowSecond, medFirst, highSecond],
+            enableAddRemoveLiquidityPaths: false,
+            maxPathsPerTokenPair: 2,
+        });
+
+        const paths = g.getCandidatePaths({
+            tokenIn: tokenA,
+            tokenOut: tokenD,
+            swapAmount: TokenAmount.fromRawAmount(tokenA, 1000n),
+            swapKind: SwapKind.GivenIn,
+            graphTraversalConfig: {
+                ...baseConfig,
+                approxPathsToReturn: 10,
+                maxRanksPerSegment: 2,
+                minSwapAmountRatio: 0.0,
+            },
+        });
+
+        expect(paths.length).toBeGreaterThan(0);
+
+        // Test that beam search generates multiple path combinations when available
+        // The algorithm should explore different combinations of pools across segments
+        const pathPools = paths.map((path) => path.pools.map((p) => p.id));
+
+        // Should have at least one path (the algorithm always returns some result)
+        expect(pathPools.length).toBeGreaterThanOrEqual(1);
+
+        // Verify that valid pool combinations are created
+        for (const poolIds of pathPools) {
+            expect(poolIds.length).toBe(2); // Two-hop path
+            expect(['highFirst', 'medFirst']).toContain(poolIds[0]);
+            expect(['lowSecond', 'highSecond']).toContain(poolIds[1]);
+        }
+    });
+
+    test('beam search maintains diversity across multiple good paths', () => {
+        const g = new PathGraphBeam();
+
+        // Create multiple paths with similar quality to test diversity
+        const mid1 = new Token(1, '0xmid1', 18);
+        const mid2 = new Token(1, '0xmid2', 18);
+
+        // Path 1: A -> mid1 -> D
+        const path1_seg1 = createMockPool('p1s1', [tokenA, mid1], { getNormalizedLiquidity: () => 900n });
+        const path1_seg2 = createMockPool('p1s2', [mid1, tokenD], { getNormalizedLiquidity: () => 850n });
+
+        // Path 2: A -> mid2 -> D
+        const path2_seg1 = createMockPool('p2s1', [tokenA, mid2], { getNormalizedLiquidity: () => 880n });
+        const path2_seg2 = createMockPool('p2s2', [mid2, tokenD], { getNormalizedLiquidity: () => 870n });
+
+        g.buildGraph({
+            pools: [path1_seg1, path1_seg2, path2_seg1, path2_seg2],
+            enableAddRemoveLiquidityPaths: false,
+        });
+
+        const paths = g.getCandidatePaths({
+            tokenIn: tokenA,
+            tokenOut: tokenD,
+            swapAmount: TokenAmount.fromRawAmount(tokenA, 1000n),
+            swapKind: SwapKind.GivenIn,
+            graphTraversalConfig: {
+                ...baseConfig,
+                approxPathsToReturn: 5,
+                minSwapAmountRatio: 0.0,
+            },
+        });
+
+        // Should find both paths since they have similar quality
+        expect(paths.length).toBe(2);
+
+        const usedMidTokens = new Set(paths.map((path) => path.tokens[1].address));
+        expect(usedMidTokens.size).toBe(2); // Should use both mid tokens for diversity
+    });
+
+    test('handles add/remove liquidity paths when enabled', () => {
+        const g = new PathGraphBeam();
+
+        // Create a more realistic scenario for add/remove liquidity paths
+        // When enabled, pools can act as intermediate "tokens" for routing
+        const bptPool = createMockPool('0xbptpool', [tokenA, tokenB]);
+        const regularPool = createMockPool('regular', [tokenB, tokenC]);
+
+        g.buildGraph({
+            pools: [bptPool, regularPool],
+            enableAddRemoveLiquidityPaths: true,
+        });
+
+        const paths = g.getCandidatePaths({
+            tokenIn: tokenA,
+            tokenOut: tokenC,
+            swapAmount: TokenAmount.fromRawAmount(tokenA, 1000n),
+            swapKind: SwapKind.GivenIn,
+            graphTraversalConfig: { ...baseConfig },
+        });
+
+        // Should find the regular path A -> B -> C
+        expect(paths.length).toBeGreaterThan(0);
+
+        // Verify we can route through the intermediate token
+        const pathExists = paths.some(
+            (path) =>
+                path.tokens.length === 3 &&
+                path.tokens[0].address === tokenA.address &&
+                path.tokens[1].address === tokenB.address &&
+                path.tokens[2].address === tokenC.address,
+        );
+        expect(pathExists).toBe(true);
+
+        // When enableAddRemoveLiquidityPaths is true, the pool address should be added as a potential node
+        const nodes = (g as any).nodes;
+        expect(nodes.has('0xbptpool')).toBe(true);
+    });
+
+    test('returns empty array when no edges exist for input token', () => {
+        const g = new PathGraphBeam();
+        const orphanToken = new Token(1, '0xorphan', 18);
+
+        g.buildGraph({ pools: [createMockPool('p1', [tokenA, tokenB])], enableAddRemoveLiquidityPaths: false });
+
+        const paths = g.getCandidatePaths({
+            tokenIn: orphanToken, // Not connected to any pool
+            tokenOut: tokenB,
+            swapAmount: TokenAmount.fromRawAmount(orphanToken, 1000n),
+            swapKind: SwapKind.GivenIn,
+            graphTraversalConfig: { ...baseConfig },
+        });
+
+        expect(paths.length).toBe(0);
+    });
+
+    test('returns empty array when no edges exist for output token', () => {
+        const g = new PathGraphBeam();
+        const orphanToken = new Token(1, '0xorphan', 18);
+
+        g.buildGraph({ pools: [createMockPool('p1', [tokenA, tokenB])], enableAddRemoveLiquidityPaths: false });
+
+        const paths = g.getCandidatePaths({
+            tokenIn: tokenA,
+            tokenOut: orphanToken, // Not connected to any pool
+            swapAmount: TokenAmount.fromRawAmount(tokenA, 1000n),
+            swapKind: SwapKind.GivenIn,
+            graphTraversalConfig: { ...baseConfig },
+        });
+
+        expect(paths.length).toBe(0);
+    });
+
+    test('handles pool swap failures gracefully during limit calculation', () => {
+        const g = new PathGraphBeam();
+
+        const flakyPool = createMockPool('flaky', [tokenA, tokenB], {
+            getLimitAmountSwap: () => {
+                throw new Error('Pool swap failed');
+            },
+        });
+
+        const goodPool = createMockPool('good', [tokenA, tokenB], {
+            getLimitAmountSwap: () => 1000n,
+        });
+
+        g.buildGraph({
+            pools: [flakyPool, goodPool],
+            enableAddRemoveLiquidityPaths: false,
+            maxPathsPerTokenPair: 2,
+        });
+
+        const paths = g.getCandidatePaths({
+            tokenIn: tokenA,
+            tokenOut: tokenB,
+            swapAmount: TokenAmount.fromRawAmount(tokenA, 1000n),
+            swapKind: SwapKind.GivenIn,
+            graphTraversalConfig: {
+                ...baseConfig,
+                minSwapAmountRatio: 0.5, // requires 500n
+            },
+        });
+
+        // Should only return the good pool path, flaky pool should be filtered out
+        expect(paths.length).toBe(1);
+        expect(paths[0].pools[0].id as string).toBe('good');
+    });
+
+    test('handles zero normalizedLiquidity pools correctly', () => {
+        const g = new PathGraphBeam();
+
+        const zeroLiqPool = createMockPool('zeroLiq', [tokenA, tokenB], {
+            getNormalizedLiquidity: () => 0n,
+            getLimitAmountSwap: () => 0n,
+        });
+
+        g.buildGraph({ pools: [zeroLiqPool], enableAddRemoveLiquidityPaths: false });
+
+        const paths = g.getCandidatePaths({
+            tokenIn: tokenA,
+            tokenOut: tokenB,
+            swapAmount: TokenAmount.fromRawAmount(tokenA, 1000n),
+            swapKind: SwapKind.GivenIn,
+            graphTraversalConfig: {
+                ...baseConfig,
+                minSwapAmountRatio: 0.1, // requires 100n
+            },
+        });
+
+        expect(paths.length).toBe(0); // Should be filtered out due to insufficient limit
+    });
+
+    test('expandTokenPathWithBestRanks handles empty edge arrays', () => {
+        const g = new PathGraphBeam();
+
+        // Build graph normally
+        g.buildGraph({ pools: [createMockPool('p1', [tokenA, tokenB])], enableAddRemoveLiquidityPaths: false });
+
+        // Try to expand a path that includes a non-existent edge
+        const result = g['expandTokenPathWithBestRanks']({
+            tokenPath: [tokenA.wrapped, tokenC.wrapped], // No edge A->C exists
+            swapKind: SwapKind.GivenIn,
+            minLimitThreshold: 1n,
+            approxPathsToReturn: 5,
+            config: { ...baseConfig },
+        });
+
+        expect(result.length).toBe(0);
+    });
+
+    test('isValidPath correctly validates complex path constraints', () => {
+        const g = new PathGraphBeam();
+
+        const bufferPool1 = createMockPool('buf1', [tokenA, tokenB], { poolType: 'Buffer' });
+        const bufferPool2 = createMockPool('buf2', [tokenB, tokenC], { poolType: 'Buffer' });
+        const bufferPool3 = createMockPool('buf3', [tokenC, tokenD], { poolType: 'Buffer' });
+
+        g.buildGraph({
+            pools: [bufferPool1, bufferPool2, bufferPool3],
+            enableAddRemoveLiquidityPaths: false,
+        });
+
+        // Create a path with 3 buffers
+        const pathWith3Buffers = [
+            { pool: bufferPool1, tokenIn: tokenA, tokenOut: tokenB, isBuffer: true, normalizedLiquidity: 100n },
+            { pool: bufferPool2, tokenIn: tokenB, tokenOut: tokenC, isBuffer: true, normalizedLiquidity: 100n },
+            { pool: bufferPool3, tokenIn: tokenC, tokenOut: tokenD, isBuffer: true, normalizedLiquidity: 100n },
+        ];
+
+        const validResult = g['isValidPath']({
+            path: pathWith3Buffers,
+            config: { ...baseConfig, maxBuffersInPath: 5 },
+        });
+
+        const invalidResult = g['isValidPath']({
+            path: pathWith3Buffers,
+            config: { ...baseConfig, maxBuffersInPath: 2 },
+        });
+
+        expect(validResult).toBe(true);
+        expect(invalidResult).toBe(false);
+    });
+
+    test('detects phantom BPT nodes correctly', () => {
+        const g = new PathGraphBeam();
+
+        // Create a scenario where a pool address is also used as a token
+        const phantomBptToken = new Token(1, '0xpool123', 18);
+        const regularToken = new Token(1, '0xregular', 18);
+
+        // Create a pool where the pool address matches phantomBptToken address
+        const poolWithBpt = createMockPool('0xpool123', [tokenA, tokenB]);
+        const regularPool = createMockPool('regular', [phantomBptToken, regularToken]);
+
+        g.buildGraph({
+            pools: [poolWithBpt, regularPool],
+            enableAddRemoveLiquidityPaths: true,
+        });
+
+        // Check that phantom BPT node is detected
+        const nodes = (g as any).nodes;
+        expect(nodes.get(phantomBptToken.wrapped)?.isPhantomBpt).toBe(true);
+        expect(nodes.get(tokenA.wrapped)?.isPhantomBpt).toBe(false);
+
+        // Note: The boosted path constraints (maxNonBoostedPathDepth, maxNonBoostedHopTokensInBoostedPath)
+        // are documented in the config but not yet implemented in the beam algorithm
+    });
+
+    describe('missing boosted path constraints', () => {
+        // DOCUMENTATION: The following constraints are mentioned in comments but not implemented:
+        //
+        // 1. maxNonBoostedPathDepth - should limit path depth for non-boosted paths
+        // 2. maxNonBoostedHopTokensInBoostedPath - should limit non-boosted hops in boosted paths
+        //
+        // These constraints exist in the config interface comments but are not enforced
+        // in the PathGraphBeam implementation. The algorithm currently only enforces:
+        // - maxDepth (overall path depth limit)
+        // - maxBuffersInPath (buffer pool count limit)
+        // - maxTokenPaths (token path discovery limit)
+        //
+        // TODO: Implement the missing boosted path validation logic
+
+        test('documents missing boosted path constraints', () => {
+            // This test serves as documentation of missing functionality
+            const _configWithBoostedConstraints = {
+                ...baseConfig,
+                maxNonBoostedPathDepth: 3,
+                maxNonBoostedHopTokensInBoostedPath: 2,
+            };
+
+            // These constraints are not currently validated by the algorithm
+            // They should be implemented to restrict paths based on phantom BPT presence
+            expect(true).toBe(true); // Placeholder - constraints not implemented
+        });
+    });
+
+    describe('performance-safety invariants', () => {
+        const tokenA = new Token(1, '0xa', 18);
+        const tokenB = new Token(1, '0xb', 18);
+        const tokenC = new Token(1, '0xc', 18);
+
+        test('edges are trimmed to top-K and kept in descending normalizedLiquidity order', () => {
+            const g = new PathGraphBeam();
+
+            const pAB4 = createMockPool('pAB4', [tokenA, tokenB], { getNormalizedLiquidity: () => 400n });
+            const pAB3 = createMockPool('pAB3', [tokenA, tokenB], { getNormalizedLiquidity: () => 300n });
+            const pAB2 = createMockPool('pAB2', [tokenA, tokenB], { getNormalizedLiquidity: () => 200n });
+            const pAB1 = createMockPool('pAB1', [tokenA, tokenB], { getNormalizedLiquidity: () => 100n });
+
+            g.buildGraph({
+                pools: [pAB1, pAB2, pAB3, pAB4],
+                enableAddRemoveLiquidityPaths: false,
+                maxPathsPerTokenPair: 3,
+            });
+
+            const edges = (g as any).edges.get(tokenA.wrapped).get(tokenB.wrapped);
+            const liqs = edges.map((e: any) => e.normalizedLiquidity);
+
+            expect(edges.length).toBe(3);
+            expect(liqs).toEqual([400n, 300n, 200n]); // strictly descending and top-3 kept
+        });
+
+        test('expandTokenPathWithBestRanks respects approxPathsToReturn cap', () => {
+            const g = new PathGraphBeam();
+
+            const abPools = Array.from({ length: 5 }, (_, i) =>
+                createMockPool(`pAB${i}`, [tokenA, tokenB], { getNormalizedLiquidity: () => BigInt(1000 - i) }),
+            );
+            const bcPools = Array.from({ length: 5 }, (_, i) =>
+                createMockPool(`pBC${i}`, [tokenB, tokenC], { getNormalizedLiquidity: () => BigInt(1000 - i) }),
+            );
+
+            g.buildGraph({
+                pools: [...abPools, ...bcPools],
+                enableAddRemoveLiquidityPaths: false,
+                maxPathsPerTokenPair: 5,
+            });
+
+            const result = (g as any).expandTokenPathWithBestRanks({
+                tokenPath: [tokenA.wrapped, tokenB.wrapped, tokenC.wrapped],
+                swapKind: SwapKind.GivenIn,
+                minLimitThreshold: 1n,
+                approxPathsToReturn: 3,
+                config: { ...baseConfig, maxRanksPerSegment: 5 },
+            });
+
+            expect(result.length).toBeLessThanOrEqual(3);
+        });
+
+        test('getCandidatePaths respects approxPathsToReturn when there is only a single token path', () => {
+            const g = new PathGraphBeam();
+
+            const abPools = Array.from({ length: 6 }, (_, i) =>
+                createMockPool(`pAB${i}`, [tokenA, tokenB], { getNormalizedLiquidity: () => BigInt(1000 - i) }),
+            );
+            const bcPools = Array.from({ length: 6 }, (_, i) =>
+                createMockPool(`pBC${i}`, [tokenB, tokenC], { getNormalizedLiquidity: () => BigInt(1000 - i) }),
+            );
+
+            g.buildGraph({
+                pools: [...abPools, ...bcPools],
+                enableAddRemoveLiquidityPaths: false,
+                maxPathsPerTokenPair: 6,
+            });
+
+            const paths = g.getCandidatePaths({
+                tokenIn: tokenA,
+                tokenOut: tokenC,
+                swapAmount: TokenAmount.fromRawAmount(tokenA, 1_000n),
+                swapKind: SwapKind.GivenIn,
+                graphTraversalConfig: {
+                    ...baseConfig,
+                    approxPathsToReturn: 5,
+                    maxRanksPerSegment: 6,
+                    minSwapAmountRatio: 0.0,
+                },
+            });
+
+            expect(paths.length).toBeLessThanOrEqual(5);
+        });
+    });
+});

--- a/modules/sor/lib/pathGraph/pathGraph-beam.ts
+++ b/modules/sor/lib/pathGraph/pathGraph-beam.ts
@@ -2,14 +2,14 @@ import { Address, SwapKind, Token, TokenAmount } from '@balancer/sdk';
 import { PathGraphEdgeData, PathGraphTraversalConfig } from './pathGraphTypes';
 import { BasePool } from '../poolsV2/basePool';
 import { PathLocal } from '../path';
+import { formatUnits } from 'viem';
 
-const DEFAULT_MAX_PATHS_PER_TOKEN_PAIR = 10;
+const DEFAULT_MAX_PATHS_PER_TOKEN_PAIR = 4;
 
 export class PathGraphBeam {
     private nodes: Map<string, { isPhantomBpt: boolean }>;
     private edges: Map<string, Map<string, PathGraphEdgeData[]>>;
     private poolAddressMap: Map<string, BasePool>;
-    private maxPathsPerTokenPair = DEFAULT_MAX_PATHS_PER_TOKEN_PAIR;
 
     constructor() {
         this.nodes = new Map();
@@ -24,39 +24,36 @@ export class PathGraphBeam {
     // (b) For any token pair x -> y, we include only the most liquid ${maxPathsPerTokenPair}
     // pool pairs (default 2).
 
-    // Add this private cache in the class
-    private edgeLimitCache: Map<string, bigint> = new Map();
-
     // In buildGraph() reset the cache so it doesn't leak across builds
     public buildGraph({
         pools,
         maxPathsPerTokenPair = DEFAULT_MAX_PATHS_PER_TOKEN_PAIR,
         enableAddRemoveLiquidityPaths,
+        swapKind,
+        tokenPrices,
+        minLimitThresholdUSD,
     }: {
         pools: BasePool[];
         maxPathsPerTokenPair?: number;
         enableAddRemoveLiquidityPaths: boolean;
+        swapKind?: SwapKind;
+        tokenPrices?: Map<string, number>;
+        minLimitThresholdUSD?: number;
     }) {
         this.poolAddressMap = new Map();
         this.nodes = new Map();
         this.edges = new Map();
-        this.edgeLimitCache = new Map(); // <-- reset cache
-        this.maxPathsPerTokenPair = maxPathsPerTokenPair;
 
         this.buildPoolAddressMap(pools);
         this.addAllTokensAsGraphNodes({ pools, enableAddRemoveLiquidityPaths });
-        this.addTokenPairsAsGraphEdges({ pools, maxPathsPerTokenPair, enableAddRemoveLiquidityPaths });
-    }
-
-    // Small helper for cached per-edge limit (optimistic bound)
-    private getEdgeLimitCached(edge: PathGraphEdgeData, swapKind: SwapKind): bigint {
-        const key = `${edge.pool.id}|${edge.tokenIn}|${edge.tokenOut}|${swapKind}`;
-        let v = this.edgeLimitCache.get(key);
-        if (v === undefined) {
-            v = edge.pool.getLimitAmountSwap(edge.tokenIn, edge.tokenOut, swapKind);
-            this.edgeLimitCache.set(key, v);
-        }
-        return v;
+        this.addTokenPairsAsGraphEdges({
+            pools,
+            maxPathsPerTokenPair,
+            enableAddRemoveLiquidityPaths,
+            swapKind,
+            tokenPrices,
+            minLimitThresholdUSD,
+        });
     }
 
     // Since the path combinations here can get quite large, we use configurable parameters
@@ -119,7 +116,6 @@ export class PathGraphBeam {
                 tokenPath,
                 swapKind,
                 minLimitThreshold,
-                maxRanksPerSegment: config.maxRanksPerSegment,
                 approxPathsToReturn: config.approxPathsToReturn,
             });
 
@@ -131,7 +127,7 @@ export class PathGraphBeam {
             }
         }
 
-        return this.sortAndFilterPaths(paths).map((path) => {
+        return paths.map((path) => {
             const pathTokens: Token[] = [...path.map((segment) => segment.tokenOut)];
             pathTokens.unshift(tokenIn);
             pathTokens[pathTokens.length - 1] = tokenOut;
@@ -142,44 +138,6 @@ export class PathGraphBeam {
                 path.map((segment) => segment.isBuffer),
             );
         });
-    }
-
-    private sortAndFilterPaths(paths: PathGraphEdgeData[][]): PathGraphEdgeData[][] {
-        const pathsWithLimits = paths
-            .map((path) => {
-                try {
-                    const limit = this.getLimitAmountSwapForPath(path, SwapKind.GivenIn);
-                    return { path, limit };
-                } catch (_e) {
-                    console.log('Error getting limit for path', path.map((p) => p.pool.id).join(' -> '));
-                    return undefined;
-                }
-            })
-            .filter((path): path is { path: PathGraphEdgeData[]; limit: bigint } => !!path)
-            .sort((a, b) => (a.limit < b.limit ? 1 : -1));
-
-        const filtered: PathGraphEdgeData[][] = [];
-
-        // Remove any paths with duplicate pools. since the paths are now sorted by limit,
-        // selecting the first path will always be the optimal.
-        for (const { path } of pathsWithLimits) {
-            let seenPools: string[] = [];
-            let isValid = true;
-
-            for (const segment of path) {
-                if (seenPools.includes(segment.pool.id)) {
-                    isValid = false;
-                    break;
-                }
-            }
-
-            if (isValid) {
-                filtered.push(path);
-                seenPools = [...seenPools, ...path.map((segment) => segment.pool.id)];
-            }
-        }
-
-        return filtered;
     }
 
     private buildPoolAddressMap(pools: BasePool[]) {
@@ -212,10 +170,16 @@ export class PathGraphBeam {
         pools,
         maxPathsPerTokenPair,
         enableAddRemoveLiquidityPaths,
+        swapKind,
+        tokenPrices,
+        minLimitThresholdUSD,
     }: {
         pools: BasePool[];
         maxPathsPerTokenPair: number;
         enableAddRemoveLiquidityPaths: boolean;
+        swapKind?: SwapKind;
+        tokenPrices?: Map<string, number>;
+        minLimitThresholdUSD?: number;
     }) {
         for (const pool of pools) {
             const tokens = [...pool.tokens.map((t) => t.token)];
@@ -225,16 +189,16 @@ export class PathGraphBeam {
             for (const tokenIn of tokens) {
                 for (const tokenOut of tokens) {
                     if (tokenIn === tokenOut) continue;
-                    this.addEdge({
-                        edgeProps: {
-                            pool,
-                            tokenIn,
-                            tokenOut,
-                            normalizedLiquidity: pool.getNormalizedLiquidity(tokenIn, tokenOut),
-                            isBuffer: pool.poolType === 'Buffer',
-                        },
-                        maxPathsPerTokenPair,
-                    });
+                    const edgeProps = this.buildEdgeProps({ pool, tokenIn, tokenOut, swapKind, tokenPrices });
+                    // Skip edges whose USD limit is known and below threshold; allow undefined to pass
+                    if (
+                        minLimitThresholdUSD !== undefined &&
+                        edgeProps.limitUSD !== undefined &&
+                        edgeProps.limitUSD < minLimitThresholdUSD
+                    ) {
+                        continue;
+                    }
+                    this.addEdge({ edgeProps, maxPathsPerTokenPair });
                 }
             }
         }
@@ -248,6 +212,45 @@ export class PathGraphBeam {
         if (!this.edges.has(token.wrapped)) {
             this.edges.set(token.wrapped, new Map());
         }
+    }
+
+    // Build edge properties including optional limitUSD using tokenPrices for the given swapKind
+    private buildEdgeProps({
+        pool,
+        tokenIn,
+        tokenOut,
+        swapKind,
+        tokenPrices,
+    }: {
+        pool: BasePool;
+        tokenIn: Token;
+        tokenOut: Token;
+        swapKind?: SwapKind;
+        tokenPrices?: Map<string, number>;
+    }): PathGraphEdgeData {
+        let limitUSD: number | undefined = undefined;
+        if (swapKind && tokenPrices) {
+            try {
+                const limit = pool.getLimitAmountSwap(tokenIn, tokenOut, swapKind);
+                const priceToken = (swapKind as any) === SwapKind.GivenIn ? tokenIn : tokenOut;
+                const price = tokenPrices.get(priceToken.wrapped.toLowerCase());
+                if (price !== undefined) {
+                    const amount = Number(formatUnits(limit, priceToken.decimals));
+                    limitUSD = amount * price;
+                }
+            } catch (_e) {
+                // leave limitUSD undefined if anything fails
+            }
+        }
+
+        return {
+            pool,
+            tokenIn,
+            tokenOut,
+            normalizedLiquidity: pool.getNormalizedLiquidity(tokenIn, tokenOut),
+            isBuffer: pool.poolType === 'Buffer',
+            limitUSD,
+        };
     }
 
     /**
@@ -268,7 +271,6 @@ export class PathGraphBeam {
             throw new Error('Attempting to add invalid edge');
         }
 
-        const hasPhantomBpt = tokenInVertex.isPhantomBpt || tokenOutVertex.isPhantomBpt;
         const existingEdges = tokenInNode.get(edgeProps.tokenOut.wrapped) || [];
 
         //TODO: ideally we don't call sort every time, this isn't performant
@@ -276,11 +278,9 @@ export class PathGraphBeam {
             a.normalizedLiquidity > b.normalizedLiquidity ? -1 : 1,
         );
 
-        // TODO: double check if the hasPhantomBpt issue is not affecting v3 liquidity more frequently (considering all
-        // pools have their BPT artificially added so we consider them for add/remove liquidity steps)
         tokenInNode.set(
             edgeProps.tokenOut.wrapped,
-            sorted.length > maxPathsPerTokenPair && !hasPhantomBpt ? sorted.slice(0, maxPathsPerTokenPair) : sorted,
+            sorted.length > maxPathsPerTokenPair ? sorted.slice(0, maxPathsPerTokenPair) : sorted,
         );
     }
 
@@ -296,88 +296,64 @@ export class PathGraphBeam {
         const results: string[][] = [];
         if (tokenIn === tokenOut) return [[tokenIn]];
 
-        // State tracked incrementally to avoid rescanning the whole path
-        const path: string[] = [tokenIn];
-        const visited = new Set<string>([tokenIn]);
-
-        // We use an iterative DFS (non-recursive) for performance.
-        // Ordering doesn’t matter since caller sorts by length later.
-        type Frame = {
-            token: string;
-            iter: IterableIterator<[string, PathGraphEdgeData[]]>;
-            isBoosted: boolean;
+        // Use BFS queue instead of DFS stack
+        type QueueItem = {
+            node: string;
+            path: string[];
             numStandardHopTokens: number;
         };
 
-        const startNeighbors = this.edges.get(tokenIn)?.entries() ?? new Map<string, PathGraphEdgeData[]>().entries();
-        let current: Frame = {
-            token: tokenIn,
-            iter: startNeighbors,
-            isBoosted: this.poolAddressMap.has(tokenIn),
-            numStandardHopTokens: 0,
-        };
-        const stack: Frame[] = [];
+        const queue: QueueItem[] = [
+            {
+                node: tokenIn,
+                path: [tokenIn],
+                numStandardHopTokens: 0,
+            },
+        ];
 
         // Respect the "approxPathsToReturn" as an upper bound (per docs).
         const maxTokenPaths = Math.max(1, config.approxPathsToReturn);
 
-        outer: while (true) {
-            const step = current.iter.next();
+        while (queue.length > 0 && results.length < maxTokenPaths) {
+            const { node, path, numStandardHopTokens } = queue.shift()!;
 
-            if (step.done) {
-                // backtrack
-                if (stack.length === 0) break;
-                const lastNode = path.pop()!;
-                visited.delete(lastNode);
-                current = stack.pop()!;
-                continue;
+            const neighbors = this.edges.get(node);
+            if (!neighbors) continue;
+
+            for (const [neighbor] of neighbors) {
+                // No revisiting the same token
+                if (path.includes(neighbor)) continue;
+
+                const nextDepth = path.length + 1;
+                if (nextDepth > config.maxDepth) continue;
+
+                // Count hop tokens excluding endpoints
+                const isHopToken = neighbor !== tokenIn && neighbor !== tokenOut;
+                const nextNumStandardHopTokens = numStandardHopTokens + (isHopToken ? 1 : 0);
+
+                if (
+                    nextDepth > config.maxNonBoostedPathDepth &&
+                    nextNumStandardHopTokens > config.maxNonBoostedHopTokensInBoostedPath
+                ) {
+                    continue;
+                }
+
+                const newPath = [...path, neighbor];
+
+                if (neighbor === tokenOut) {
+                    // Complete path checks
+                    if (nextDepth > config.maxNonBoostedPathDepth) continue;
+                    results.push(newPath);
+                    if (results.length >= maxTokenPaths) break;
+                } else {
+                    // Add to queue for further exploration (BFS)
+                    queue.push({
+                        node: neighbor,
+                        path: newPath,
+                        numStandardHopTokens: nextNumStandardHopTokens,
+                    });
+                }
             }
-
-            const neighbor = step.value[0];
-
-            // No revisiting the same token
-            if (visited.has(neighbor)) continue;
-
-            const nextDepth = path.length + 1;
-            if (nextDepth > config.maxDepth) continue;
-
-            const neighborIsPhantom = this.poolAddressMap.has(neighbor);
-            const nextIsBoosted = current.isBoosted || neighborIsPhantom;
-
-            // Count hop tokens excluding endpoints
-            const isHopToken = neighbor !== tokenIn && neighbor !== tokenOut;
-            const nextNumStandardHopTokens = current.numStandardHopTokens + (isHopToken && !neighborIsPhantom ? 1 : 0);
-
-            // Prune using the same rules as isValidTokenPath but incrementally
-            if (nextIsBoosted && nextNumStandardHopTokens > config.maxNonBoostedHopTokensInBoostedPath) continue;
-
-            if (
-                nextDepth > config.maxNonBoostedPathDepth &&
-                nextNumStandardHopTokens > config.maxNonBoostedHopTokensInBoostedPath
-            ) {
-                continue;
-            }
-
-            if (neighbor === tokenOut) {
-                // Complete path checks
-                if (!nextIsBoosted && nextDepth > config.maxNonBoostedPathDepth) continue;
-                results.push([...path, neighbor]);
-                if (results.length >= maxTokenPaths) break outer;
-                continue;
-            }
-
-            // Go deeper
-            path.push(neighbor);
-            visited.add(neighbor);
-
-            // Save current frame and descend
-            stack.push(current);
-            current = {
-                token: neighbor,
-                iter: this.edges.get(neighbor)?.entries() ?? new Map<string, PathGraphEdgeData[]>().entries(),
-                isBoosted: nextIsBoosted,
-                numStandardHopTokens: nextNumStandardHopTokens,
-            };
         }
 
         return results;
@@ -444,6 +420,27 @@ export class PathGraphBeam {
         return id;
     }
 
+    // please add a description to how this function works internally
+    /**
+     * Calculates the maximum feasible swap size for a given path.
+     * @param path - The path to calculate the limit for.
+     * @param swapKind - The type of swap to calculate the limit for.
+     * @returns The maximum feasible swap size for the path.
+     *
+     * This function works by starting with the last segment of the path and working backwards.
+     * It calculates the limit for the last segment using the getLimitAmountSwap method.
+     * Then, it iterates through the remaining segments, calculating the limit for each segment.
+     * The limit for each segment is the minimum of the limit for the previous segment and the limit for the current segment.
+     * If the limit for the current segment is greater than the limit for the previous segment, it means that the current segment is the bottleneck.
+     * In this case, the function calculates the limit for the current segment by pulling the limit from the previous segment.
+     * The function returns the limit for the first segment.
+     *
+     * This function is used to calculate the limit for a given path.
+     * The limit is used to determine if a path is valid.
+     * The limit is also used to determine the best path to use.
+     *
+     *
+     */
     private getLimitAmountSwapForPath(path: PathGraphEdgeData[], swapKind: SwapKind): bigint {
         let limit = path[path.length - 1].pool.getLimitAmountSwap(
             path[path.length - 1].tokenIn,
@@ -494,13 +491,11 @@ export class PathGraphBeam {
         tokenPath,
         swapKind,
         minLimitThreshold,
-        maxRanksPerSegment,
         approxPathsToReturn,
     }: {
         tokenPath: string[];
         swapKind: SwapKind;
         minLimitThreshold: bigint;
-        maxRanksPerSegment: number;
         approxPathsToReturn: number;
     }): PathGraphEdgeData[][] {
         const segmentCount = tokenPath.length - 1;
@@ -509,83 +504,64 @@ export class PathGraphBeam {
         // Gather candidate edges per segment (already sorted by normalizedLiquidity desc).
         const perSegmentEdges: PathGraphEdgeData[][] = new Array(segmentCount);
         for (let i = 0; i < segmentCount; i++) {
-            const edges = this.edges.get(tokenPath[i])?.get(tokenPath[i + 1]) ?? [];
-            if (edges.length === 0) return []; // path cannot be built
-            // Limit choices per segment
-            perSegmentEdges[i] = edges.slice(0, Math.min(edges.length, maxRanksPerSegment, this.maxPathsPerTokenPair));
+            const edges = this.edges.get(tokenPath[i])?.get(tokenPath[i + 1]);
+            if (!edges) return []; // path cannot be built
+            perSegmentEdges[i] = edges;
         }
 
-        // Precompute optimistic bound per candidate edge (cached)
-        const perSegmentEdgeBounds: bigint[][] = perSegmentEdges.map((edges) =>
-            edges.map((e) => this.getEdgeLimitCached(e, swapKind)),
-        );
-
-        // Beam search: keep only the top K partial combos by optimistic bound
-        type Partial = { ranks: number[]; bound: bigint };
-        let partials: Partial[] = [{ ranks: [], bound: 0n }]; // bound will be set on first expansion
+        // Beam search: keep only the top K partial combos by bottleneck normalizedLiquidity
+        type Partial = { ranks: number[]; boundNL: bigint };
+        let partials: Partial[] = [{ ranks: [], boundNL: 0n }];
 
         // Make the beam wider than the final number to ensure diversity
-        const beamWidth = Math.max(approxPathsToReturn * 3, approxPathsToReturn);
+        const beamWidth = Math.max(approxPathsToReturn * 10, approxPathsToReturn);
 
         for (let seg = 0; seg < segmentCount; seg++) {
             const edges = perSegmentEdges[seg];
-            const bounds = perSegmentEdgeBounds[seg];
             const next: Partial[] = [];
 
             for (const p of partials) {
                 for (let r = 0; r < edges.length; r++) {
-                    // optimistic bound for extended partial is min of previous bound and this edge bound
-                    const newBound = p.ranks.length === 0 ? bounds[r] : bounds[r] < p.bound ? bounds[r] : p.bound;
+                    const edge = edges[r];
 
-                    // Early prune by minLimitThreshold
-                    if (newBound < minLimitThreshold) continue;
+                    // bottleneck normalizedLiquidity across segments so far
+                    const edgeNL = edge.normalizedLiquidity;
+                    const newBoundNL = p.boundNL < edgeNL ? p.boundNL : edgeNL;
 
                     const ranks = p.ranks.length === 0 ? [r] : [...p.ranks, r];
-                    next.push({ ranks, bound: newBound });
+                    next.push({ ranks, boundNL: newBoundNL });
                 }
             }
 
             if (next.length === 0) return [];
 
-            // Keep only the best by optimistic bound (desc)
-            next.sort((a, b) => (a.bound < b.bound ? 1 : -1));
+            // Keep only the best by bottleneck NL (desc)
+            next.sort((a, b) => (a.boundNL < b.boundNL ? 1 : -1));
             partials = next.slice(0, beamWidth);
         }
 
         // Evaluate real limits only for the finalists and filter by threshold
         // This is the expensive part; we limited it by beamWidth.
         const pathsWithRealLimit: { path: PathGraphEdgeData[]; limit: bigint }[] = [];
-        const seenCombos = new Set<string>();
 
         for (const p of partials) {
-            const key = p.ranks.join(',');
-            if (seenCombos.has(key)) continue;
-            seenCombos.add(key);
-
             try {
-                const path = this.expandTokenPathWithRanks({ tokenPath, ranks: p.ranks });
+                const path = this.expandTokenPathWithRanks({ perSegmentEdges, ranks: p.ranks });
                 const limit = this.getLimitAmountSwapForPath(path, swapKind);
                 if (limit >= minLimitThreshold) {
                     pathsWithRealLimit.push({ path, limit });
                     if (pathsWithRealLimit.length >= approxPathsToReturn) {
-                        // We can stop early if we already have enough
-                        // candidates meeting the threshold.
-                        // We will still sort below for determinism.
-                        // This keeps CPU in check on large graphs.
+                        // We can stop early if we already have enough candidates meeting the threshold.
                         break;
                     }
                 }
             } catch {
-                // Missing rank or edge; skip
+                // getLimitAmountSwapForPath failed (likely due to trade/wrap amount too small)
                 continue;
             }
         }
 
-        if (pathsWithRealLimit.length === 0) return [];
-
-        // Return top approxPathsToReturn by real limit
-        pathsWithRealLimit.sort((a, b) => (a.limit < b.limit ? 1 : -1));
-        return pathsWithRealLimit.slice(0, approxPathsToReturn).map((x) => x.path);
+        return pathsWithRealLimit.map((x) => x.path);
     }
 
     /**
@@ -594,23 +570,22 @@ export class PathGraphBeam {
      * @param tokenPath - Array of token addresses representing the path
      * @param ranks - Array of liquidity ranks to use for each segment (must match path length - 1)
      */
-    private expandTokenPathWithRanks({ tokenPath, ranks }: { tokenPath: string[]; ranks: number[] }) {
+    private expandTokenPathWithRanks({
+        perSegmentEdges,
+        ranks,
+    }: {
+        perSegmentEdges: PathGraphEdgeData[][];
+        ranks: number[];
+    }) {
         const segments: PathGraphEdgeData[] = [];
 
-        for (let i = 0; i < tokenPath.length - 1; i++) {
-            const edge = this.edges.get(tokenPath[i])?.get(tokenPath[i + 1]);
-
-            if (!edge || edge.length === 0) {
-                throw new Error(`Missing edge for pair ${tokenPath[i]} -> ${tokenPath[i + 1]}`);
-            }
-
+        for (let i = 0; i < perSegmentEdges.length; i++) {
+            const edgeChoices = perSegmentEdges[i];
             const rank = ranks[i];
-
-            if (!edge[rank]) {
-                throw new Error(`Missing rank ${rank} on edge for pair ${tokenPath[i]} -> ${tokenPath[i + 1]}`);
+            if (!edgeChoices[rank]) {
+                throw new Error('Missing rank on edge for segment');
             }
-
-            segments.push(edge[rank]);
+            segments.push(edgeChoices[rank]);
         }
 
         return segments;

--- a/modules/sor/lib/pathGraph/pathGraph-beam.ts
+++ b/modules/sor/lib/pathGraph/pathGraph-beam.ts
@@ -1,0 +1,618 @@
+import { Address, SwapKind, Token, TokenAmount } from '@balancer/sdk';
+import { PathGraphEdgeData, PathGraphTraversalConfig } from './pathGraphTypes';
+import { BasePool } from '../poolsV2/basePool';
+import { PathLocal } from '../path';
+
+const DEFAULT_MAX_PATHS_PER_TOKEN_PAIR = 10;
+
+export class PathGraph {
+    private nodes: Map<string, { isPhantomBpt: boolean }>;
+    private edges: Map<string, Map<string, PathGraphEdgeData[]>>;
+    private poolAddressMap: Map<string, BasePool>;
+    private maxPathsPerTokenPair = DEFAULT_MAX_PATHS_PER_TOKEN_PAIR;
+
+    constructor() {
+        this.nodes = new Map();
+        this.edges = new Map();
+        this.poolAddressMap = new Map();
+    }
+
+    // We build a directed graph for all pools.
+    // Nodes are tokens and edges are triads: [pool.id, tokenIn, tokenOut].
+    // The current criterion for including a pool path into this graph is the following:
+    // (a) We include every path that includes a phantom BPT.
+    // (b) For any token pair x -> y, we include only the most liquid ${maxPathsPerTokenPair}
+    // pool pairs (default 2).
+
+    // Add this private cache in the class
+    private edgeLimitCache: Map<string, bigint> = new Map();
+
+    // In buildGraph() reset the cache so it doesn't leak across builds
+    public buildGraph({
+        pools,
+        maxPathsPerTokenPair = DEFAULT_MAX_PATHS_PER_TOKEN_PAIR,
+        enableAddRemoveLiquidityPaths,
+    }: {
+        pools: BasePool[];
+        maxPathsPerTokenPair?: number;
+        enableAddRemoveLiquidityPaths: boolean;
+    }) {
+        this.poolAddressMap = new Map();
+        this.nodes = new Map();
+        this.edges = new Map();
+        this.edgeLimitCache = new Map(); // <-- reset cache
+        this.maxPathsPerTokenPair = maxPathsPerTokenPair;
+
+        this.buildPoolAddressMap(pools);
+        this.addAllTokensAsGraphNodes({ pools, enableAddRemoveLiquidityPaths });
+        this.addTokenPairsAsGraphEdges({ pools, maxPathsPerTokenPair, enableAddRemoveLiquidityPaths });
+    }
+
+    // Small helper for cached per-edge limit (optimistic bound)
+    private getEdgeLimitCached(edge: PathGraphEdgeData, swapKind: SwapKind): bigint {
+        const key = `${edge.pool.id}|${edge.tokenIn}|${edge.tokenOut}|${swapKind}`;
+        let v = this.edgeLimitCache.get(key);
+        if (v === undefined) {
+            v = edge.pool.getLimitAmountSwap(edge.tokenIn, edge.tokenOut, swapKind);
+            this.edgeLimitCache.set(key, v);
+        }
+        return v;
+    }
+
+    // Since the path combinations here can get quite large, we use configurable parameters
+    // to enforce upper limits across several dimensions, defined in the pathConfig.
+    // (a) maxDepth - the max depth of the traversal (length of token path), defaults to 7.
+    // (b) maxNonBoostedPathDepth - the max depth for any path that does not contain a phantom bpt.
+    // (c) maxNonBoostedHopTokensInBoostedPath - The max number of non boosted hop tokens
+    // allowed in a boosted path.
+    // (d) approxPathsToReturn - search for up to this many paths. Since all paths for a single traversal
+    // are added, its possible that the amount returned is larger than this number.
+    // (e) poolIdsToInclude - Only include paths with these poolIds (optional)
+
+    // Additionally, we impose the following requirements for a path to be considered valid
+    // (a) It does not visit the same token twice
+    // (b) It does not use the same pool twice
+    public getCandidatePaths({
+        tokenIn,
+        tokenOut,
+        swapAmount,
+        swapKind,
+        graphTraversalConfig,
+    }: {
+        tokenIn: Token;
+        tokenOut: Token;
+        swapAmount: TokenAmount;
+        swapKind: SwapKind;
+        graphTraversalConfig?: Partial<PathGraphTraversalConfig>;
+    }): PathLocal[] {
+        const isHyperEvm = tokenIn.chainId === 999;
+
+        // apply defaults, allowing caller override whatever they'd like
+        const config: PathGraphTraversalConfig = {
+            maxDepth: 6,
+            maxNonBoostedPathDepth: 3,
+            maxNonBoostedHopTokensInBoostedPath: 2,
+            maxBuffersInPath: isHyperEvm ? 2 : 5, // limited only on HyperEvm due to gas cost limits on small blocks - virtually unlimited otherwise
+            approxPathsToReturn: 20, // Default to 20 - likely won't be reached, but acts as a bound to the computation if needed
+            maxRanksPerSegment: 2, // Default 2 for diversity
+            minSwapAmountRatio: 0.5, // Default to 50% so we're sure selected paths support splitPath logic
+            ...graphTraversalConfig,
+        };
+
+        // Calculate minimum limit threshold based on swap amount and ratio
+        const minLimitThreshold = (swapAmount.amount * BigInt(Math.floor(config.minSwapAmountRatio * 100))) / 100n;
+
+        const tokenPaths = this.findAllValidTokenPaths({
+            token: tokenIn.wrapped,
+            tokenIn: tokenIn.wrapped,
+            tokenOut: tokenOut.wrapped,
+            config,
+            tokenPath: [tokenIn.wrapped],
+        }).sort((a, b) => (a.length < b.length ? -1 : 1));
+
+        const paths: PathGraphEdgeData[][] = [];
+        const selectedPathIds: string[] = [];
+
+        // Use the new greedy best-first approach for each token path
+        for (const tokenPath of tokenPaths) {
+            const expandedPaths = this.expandTokenPathWithBestRanks({
+                tokenPath,
+                swapKind,
+                minLimitThreshold,
+                maxRanksPerSegment: config.maxRanksPerSegment,
+                approxPathsToReturn: config.approxPathsToReturn,
+            });
+
+            for (const path of expandedPaths) {
+                if (this.isValidPath({ path, seenPoolAddresses: [], selectedPathIds, config })) {
+                    selectedPathIds.push(this.getIdForPath(path));
+                    paths.push(path);
+                }
+            }
+        }
+
+        return this.sortAndFilterPaths(paths).map((path) => {
+            const pathTokens: Token[] = [...path.map((segment) => segment.tokenOut)];
+            pathTokens.unshift(tokenIn);
+            pathTokens[pathTokens.length - 1] = tokenOut;
+
+            return new PathLocal(
+                pathTokens,
+                path.map((segment) => segment.pool),
+                path.map((segment) => segment.isBuffer),
+            );
+        });
+    }
+
+    private sortAndFilterPaths(paths: PathGraphEdgeData[][]): PathGraphEdgeData[][] {
+        const pathsWithLimits = paths
+            .map((path) => {
+                try {
+                    const limit = this.getLimitAmountSwapForPath(path, SwapKind.GivenIn);
+                    return { path, limit };
+                } catch (_e) {
+                    console.log('Error getting limit for path', path.map((p) => p.pool.id).join(' -> '));
+                    return undefined;
+                }
+            })
+            .filter((path): path is { path: PathGraphEdgeData[]; limit: bigint } => !!path)
+            .sort((a, b) => (a.limit < b.limit ? 1 : -1));
+
+        const filtered: PathGraphEdgeData[][] = [];
+
+        // Remove any paths with duplicate pools. since the paths are now sorted by limit,
+        // selecting the first path will always be the optimal.
+        for (const { path } of pathsWithLimits) {
+            let seenPools: string[] = [];
+            let isValid = true;
+
+            for (const segment of path) {
+                if (seenPools.includes(segment.pool.id)) {
+                    isValid = false;
+                    break;
+                }
+            }
+
+            if (isValid) {
+                filtered.push(path);
+                seenPools = [...seenPools, ...path.map((segment) => segment.pool.id)];
+            }
+        }
+
+        return filtered;
+    }
+
+    private buildPoolAddressMap(pools: BasePool[]) {
+        for (const pool of pools) {
+            this.poolAddressMap.set(pool.address.toLowerCase(), pool);
+        }
+    }
+
+    private addAllTokensAsGraphNodes({
+        pools,
+        enableAddRemoveLiquidityPaths,
+    }: {
+        pools: BasePool[];
+        enableAddRemoveLiquidityPaths: boolean;
+    }) {
+        for (const pool of pools) {
+            const tokens = [...pool.tokens.map((t) => t.token)];
+            if (enableAddRemoveLiquidityPaths && pool.poolType !== 'Buffer') {
+                tokens.push(new Token(pool.tokens[0].token.chainId, pool.address.toLowerCase() as Address, 18)); // Add BPT as token nodes
+            }
+            for (const token of tokens) {
+                if (!this.nodes.has(token.wrapped)) {
+                    this.addNode(token);
+                }
+            }
+        }
+    }
+
+    private addTokenPairsAsGraphEdges({
+        pools,
+        maxPathsPerTokenPair,
+        enableAddRemoveLiquidityPaths,
+    }: {
+        pools: BasePool[];
+        maxPathsPerTokenPair: number;
+        enableAddRemoveLiquidityPaths: boolean;
+    }) {
+        for (const pool of pools) {
+            const tokens = [...pool.tokens.map((t) => t.token)];
+            if (enableAddRemoveLiquidityPaths && pool.poolType !== 'Buffer') {
+                tokens.push(new Token(pool.tokens[0].token.chainId, pool.address.toLowerCase() as Address, 18)); // Also consider BPT token pairs
+            }
+            for (const tokenIn of tokens) {
+                for (const tokenOut of tokens) {
+                    if (tokenIn === tokenOut) continue;
+                    this.addEdge({
+                        edgeProps: {
+                            pool,
+                            tokenIn,
+                            tokenOut,
+                            normalizedLiquidity: pool.getNormalizedLiquidity(tokenIn, tokenOut),
+                            isBuffer: pool.poolType === 'Buffer',
+                        },
+                        maxPathsPerTokenPair,
+                    });
+                }
+            }
+        }
+    }
+
+    private addNode(token: Token): void {
+        this.nodes.set(token.wrapped, {
+            isPhantomBpt: !!this.poolAddressMap.get(token.wrapped),
+        });
+
+        if (!this.edges.has(token.wrapped)) {
+            this.edges.set(token.wrapped, new Map());
+        }
+    }
+
+    /**
+     * Adds a directed edge from a source vertex to a destination
+     */
+    private addEdge({
+        edgeProps,
+        maxPathsPerTokenPair,
+    }: {
+        edgeProps: PathGraphEdgeData;
+        maxPathsPerTokenPair: number;
+    }): void {
+        const tokenInVertex = this.nodes.get(edgeProps.tokenIn.wrapped);
+        const tokenOutVertex = this.nodes.get(edgeProps.tokenOut.wrapped);
+        const tokenInNode = this.edges.get(edgeProps.tokenIn.wrapped);
+
+        if (!tokenInVertex || !tokenOutVertex || !tokenInNode) {
+            throw new Error('Attempting to add invalid edge');
+        }
+
+        const hasPhantomBpt = tokenInVertex.isPhantomBpt || tokenOutVertex.isPhantomBpt;
+        const existingEdges = tokenInNode.get(edgeProps.tokenOut.wrapped) || [];
+
+        //TODO: ideally we don't call sort every time, this isn't performant
+        const sorted = [...existingEdges, edgeProps].sort((a, b) =>
+            a.normalizedLiquidity > b.normalizedLiquidity ? -1 : 1,
+        );
+
+        // TODO: double check if the hasPhantomBpt issue is not affecting v3 liquidity more frequently (considering all
+        // pools have their BPT artificially added so we consider them for add/remove liquidity steps)
+        tokenInNode.set(
+            edgeProps.tokenOut.wrapped,
+            sorted.length > maxPathsPerTokenPair && !hasPhantomBpt ? sorted.slice(0, maxPathsPerTokenPair) : sorted,
+        );
+    }
+
+    private findAllValidTokenPaths(args: {
+        token: string;
+        tokenIn: string;
+        tokenOut: string;
+        tokenPath: string[]; // unused in refactor; we always start from tokenIn
+        config: PathGraphTraversalConfig;
+    }): string[][] {
+        const { tokenIn, tokenOut, config } = args;
+
+        const results: string[][] = [];
+        if (tokenIn === tokenOut) return [[tokenIn]];
+
+        // State tracked incrementally to avoid rescanning the whole path
+        const path: string[] = [tokenIn];
+        const visited = new Set<string>([tokenIn]);
+
+        // We use an iterative DFS (non-recursive) for performance.
+        // Ordering doesn’t matter since caller sorts by length later.
+        type Frame = {
+            token: string;
+            iter: IterableIterator<[string, PathGraphEdgeData[]]>;
+            isBoosted: boolean;
+            numStandardHopTokens: number;
+        };
+
+        const startNeighbors = this.edges.get(tokenIn)?.entries() ?? new Map<string, PathGraphEdgeData[]>().entries();
+        let current: Frame = {
+            token: tokenIn,
+            iter: startNeighbors,
+            isBoosted: this.poolAddressMap.has(tokenIn),
+            numStandardHopTokens: 0,
+        };
+        const stack: Frame[] = [];
+
+        // Respect the "approxPathsToReturn" as an upper bound (per docs).
+        const maxTokenPaths = Math.max(1, config.approxPathsToReturn);
+
+        outer: while (true) {
+            const step = current.iter.next();
+
+            if (step.done) {
+                // backtrack
+                if (stack.length === 0) break;
+                const lastNode = path.pop()!;
+                visited.delete(lastNode);
+                current = stack.pop()!;
+                continue;
+            }
+
+            const neighbor = step.value[0];
+
+            // No revisiting the same token
+            if (visited.has(neighbor)) continue;
+
+            const nextDepth = path.length + 1;
+            if (nextDepth > config.maxDepth) continue;
+
+            const neighborIsPhantom = this.poolAddressMap.has(neighbor);
+            const nextIsBoosted = current.isBoosted || neighborIsPhantom;
+
+            // Count hop tokens excluding endpoints
+            const isHopToken = neighbor !== tokenIn && neighbor !== tokenOut;
+            const nextNumStandardHopTokens = current.numStandardHopTokens + (isHopToken && !neighborIsPhantom ? 1 : 0);
+
+            // Prune using the same rules as isValidTokenPath but incrementally
+            if (nextIsBoosted && nextNumStandardHopTokens > config.maxNonBoostedHopTokensInBoostedPath) continue;
+
+            if (
+                nextDepth > config.maxNonBoostedPathDepth &&
+                nextNumStandardHopTokens > config.maxNonBoostedHopTokensInBoostedPath
+            ) {
+                continue;
+            }
+
+            if (neighbor === tokenOut) {
+                // Complete path checks
+                if (!nextIsBoosted && nextDepth > config.maxNonBoostedPathDepth) continue;
+                results.push([...path, neighbor]);
+                if (results.length >= maxTokenPaths) break outer;
+                continue;
+            }
+
+            // Go deeper
+            path.push(neighbor);
+            visited.add(neighbor);
+
+            // Save current frame and descend
+            stack.push(current);
+            current = {
+                token: neighbor,
+                iter: this.edges.get(neighbor)?.entries() ?? new Map<string, PathGraphEdgeData[]>().entries(),
+                isBoosted: nextIsBoosted,
+                numStandardHopTokens: nextNumStandardHopTokens,
+            };
+        }
+
+        return results;
+    }
+
+    private isValidPath({
+        path,
+        seenPoolAddresses,
+        selectedPathIds,
+        config,
+    }: {
+        path: PathGraphEdgeData[];
+        seenPoolAddresses: string[];
+        selectedPathIds: string[];
+        config: PathGraphTraversalConfig;
+    }) {
+        const poolIdsInPath = path.map((segment) => segment.pool.id);
+        const uniquePools = [...new Set(poolIdsInPath)];
+
+        if (config.poolIdsToInclude) {
+            for (const poolId of poolIdsInPath) {
+                if (!config.poolIdsToInclude.map((id) => id.toLowerCase()).includes(poolId.toLowerCase())) {
+                    //path includes a pool that is not allowed for this traversal
+                    return false;
+                }
+            }
+        }
+
+        //dont include any path that hops through the same pool twice
+        if (uniquePools.length !== poolIdsInPath.length) {
+            return false;
+        }
+
+        for (const segment of path) {
+            if (seenPoolAddresses.includes(segment.pool.address)) {
+                //this path contains a pool that has already been used
+                return false;
+            }
+        }
+
+        //this is a duplicate path
+        if (selectedPathIds.includes(this.getIdForPath(path))) {
+            return false;
+        }
+
+        if (path.filter((segment) => segment.isBuffer).length > config.maxBuffersInPath) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private getIdForPath(path: PathGraphEdgeData[]): string {
+        let id = '';
+
+        for (const segment of path) {
+            if (id.length > 0) {
+                id += '_';
+            }
+
+            id += `${segment.pool.id}-${segment.tokenIn}-${segment.tokenOut}`;
+        }
+
+        return id;
+    }
+
+    private getLimitAmountSwapForPath(path: PathGraphEdgeData[], swapKind: SwapKind): bigint {
+        let limit = path[path.length - 1].pool.getLimitAmountSwap(
+            path[path.length - 1].tokenIn,
+            path[path.length - 1].tokenOut,
+            swapKind,
+        );
+
+        for (let i = path.length - 2; i >= 0; i--) {
+            const poolLimitExactIn = path[i].pool.getLimitAmountSwap(
+                path[i].tokenIn,
+                path[i].tokenOut,
+                SwapKind.GivenIn,
+            );
+            const poolLimitExactOut = path[i].pool.getLimitAmountSwap(
+                path[i].tokenIn,
+                path[i].tokenOut,
+                SwapKind.GivenOut,
+            );
+
+            if (poolLimitExactOut <= limit) {
+                limit = poolLimitExactIn;
+            } else {
+                const pulledLimit = path[i].pool.swapGivenOut(
+                    path[i].tokenIn,
+                    path[i].tokenOut,
+                    TokenAmount.fromRawAmount(path[i].tokenOut, limit),
+                ).amount;
+
+                limit = pulledLimit > poolLimitExactIn ? poolLimitExactIn : pulledLimit;
+            }
+        }
+
+        return limit;
+    }
+
+    /**
+     * Expands a token path using a greedy best-first approach with early limit checking.
+     * Instead of exploring all rank combinations, this prioritizes highest liquidity options
+     * and stops when paths meet the minimum limit threshold.
+     */
+    /**
+     * Beam-search over ranks per segment.
+     * - Precompute a cheap optimistic bound per edge using getLimitAmountSwap (cached).
+     * - Expand only top candidates by that bound before evaluating expensive full-path limit.
+     * - Keeps at most approxPathsToReturn candidates throughout.
+     */
+    private expandTokenPathWithBestRanks({
+        tokenPath,
+        swapKind,
+        minLimitThreshold,
+        maxRanksPerSegment,
+        approxPathsToReturn,
+    }: {
+        tokenPath: string[];
+        swapKind: SwapKind;
+        minLimitThreshold: bigint;
+        maxRanksPerSegment: number;
+        approxPathsToReturn: number;
+    }): PathGraphEdgeData[][] {
+        const segmentCount = tokenPath.length - 1;
+        if (segmentCount <= 0) return [];
+
+        // Gather candidate edges per segment (already sorted by normalizedLiquidity desc).
+        const perSegmentEdges: PathGraphEdgeData[][] = new Array(segmentCount);
+        for (let i = 0; i < segmentCount; i++) {
+            const edges = this.edges.get(tokenPath[i])?.get(tokenPath[i + 1]) ?? [];
+            if (edges.length === 0) return []; // path cannot be built
+            // Limit choices per segment
+            perSegmentEdges[i] = edges.slice(0, Math.min(edges.length, maxRanksPerSegment, this.maxPathsPerTokenPair));
+        }
+
+        // Precompute optimistic bound per candidate edge (cached)
+        const perSegmentEdgeBounds: bigint[][] = perSegmentEdges.map((edges) =>
+            edges.map((e) => this.getEdgeLimitCached(e, swapKind)),
+        );
+
+        // Beam search: keep only the top K partial combos by optimistic bound
+        type Partial = { ranks: number[]; bound: bigint };
+        let partials: Partial[] = [{ ranks: [], bound: 0n }]; // bound will be set on first expansion
+
+        // Make the beam wider than the final number to ensure diversity
+        const beamWidth = Math.max(approxPathsToReturn * 3, approxPathsToReturn);
+
+        for (let seg = 0; seg < segmentCount; seg++) {
+            const edges = perSegmentEdges[seg];
+            const bounds = perSegmentEdgeBounds[seg];
+            const next: Partial[] = [];
+
+            for (const p of partials) {
+                for (let r = 0; r < edges.length; r++) {
+                    // optimistic bound for extended partial is min of previous bound and this edge bound
+                    const newBound = p.ranks.length === 0 ? bounds[r] : bounds[r] < p.bound ? bounds[r] : p.bound;
+
+                    // Early prune by minLimitThreshold
+                    if (newBound < minLimitThreshold) continue;
+
+                    const ranks = p.ranks.length === 0 ? [r] : [...p.ranks, r];
+                    next.push({ ranks, bound: newBound });
+                }
+            }
+
+            if (next.length === 0) return [];
+
+            // Keep only the best by optimistic bound (desc)
+            next.sort((a, b) => (a.bound < b.bound ? 1 : -1));
+            partials = next.slice(0, beamWidth);
+        }
+
+        // Evaluate real limits only for the finalists and filter by threshold
+        // This is the expensive part; we limited it by beamWidth.
+        const pathsWithRealLimit: { path: PathGraphEdgeData[]; limit: bigint }[] = [];
+        const seenCombos = new Set<string>();
+
+        for (const p of partials) {
+            const key = p.ranks.join(',');
+            if (seenCombos.has(key)) continue;
+            seenCombos.add(key);
+
+            try {
+                const path = this.expandTokenPathWithRanks({ tokenPath, ranks: p.ranks });
+                const limit = this.getLimitAmountSwapForPath(path, swapKind);
+                if (limit >= minLimitThreshold) {
+                    pathsWithRealLimit.push({ path, limit });
+                    if (pathsWithRealLimit.length >= approxPathsToReturn) {
+                        // We can stop early if we already have enough
+                        // candidates meeting the threshold.
+                        // We will still sort below for determinism.
+                        // This keeps CPU in check on large graphs.
+                        break;
+                    }
+                }
+            } catch {
+                // Missing rank or edge; skip
+                continue;
+            }
+        }
+
+        if (pathsWithRealLimit.length === 0) return [];
+
+        // Return top approxPathsToReturn by real limit
+        pathsWithRealLimit.sort((a, b) => (a.limit < b.limit ? 1 : -1));
+        return pathsWithRealLimit.slice(0, approxPathsToReturn).map((x) => x.path);
+    }
+
+    /**
+     * Expands a token path using different liquidity ranks for each segment.
+     * This allows exploring all combinations of pool liquidity ranks for different token pairs in a path.
+     * @param tokenPath - Array of token addresses representing the path
+     * @param ranks - Array of liquidity ranks to use for each segment (must match path length - 1)
+     */
+    private expandTokenPathWithRanks({ tokenPath, ranks }: { tokenPath: string[]; ranks: number[] }) {
+        const segments: PathGraphEdgeData[] = [];
+
+        for (let i = 0; i < tokenPath.length - 1; i++) {
+            const edge = this.edges.get(tokenPath[i])?.get(tokenPath[i + 1]);
+
+            if (!edge || edge.length === 0) {
+                throw new Error(`Missing edge for pair ${tokenPath[i]} -> ${tokenPath[i + 1]}`);
+            }
+
+            const rank = ranks[i];
+
+            if (!edge[rank]) {
+                throw new Error(`Missing rank ${rank} on edge for pair ${tokenPath[i]} -> ${tokenPath[i + 1]}`);
+            }
+
+            segments.push(edge[rank]);
+        }
+
+        return segments;
+    }
+}

--- a/modules/sor/lib/pathGraph/pathGraph-beam.ts
+++ b/modules/sor/lib/pathGraph/pathGraph-beam.ts
@@ -7,12 +7,12 @@ import { formatUnits } from 'viem';
 const DEFAULT_MAX_PATHS_PER_TOKEN_PAIR = 4;
 
 export class PathGraphBeam {
-    private nodes: Map<string, { isPhantomBpt: boolean }>;
+    private nodes: Set<string>;
     private edges: Map<string, Map<string, PathGraphEdgeData[]>>;
     private poolAddressMap: Map<string, BasePool>;
 
     constructor() {
-        this.nodes = new Map();
+        this.nodes = new Set();
         this.edges = new Map();
         this.poolAddressMap = new Map();
     }
@@ -20,11 +20,8 @@ export class PathGraphBeam {
     // We build a directed graph for all pools.
     // Nodes are tokens and edges are triads: [pool.id, tokenIn, tokenOut].
     // The current criterion for including a pool path into this graph is the following:
-    // (a) We include every path that includes a phantom BPT.
-    // (b) For any token pair x -> y, we include only the most liquid ${maxPathsPerTokenPair}
+    // - For any token pair x -> y, we include only the most liquid ${maxPathsPerTokenPair}
     // pool pairs (default 2).
-
-    // In buildGraph() reset the cache so it doesn't leak across builds
     public buildGraph({
         pools,
         maxPathsPerTokenPair = DEFAULT_MAX_PATHS_PER_TOKEN_PAIR,
@@ -36,12 +33,12 @@ export class PathGraphBeam {
         pools: BasePool[];
         maxPathsPerTokenPair?: number;
         enableAddRemoveLiquidityPaths: boolean;
-        swapKind?: SwapKind;
-        tokenPrices?: Map<string, number>;
-        minLimitThresholdUSD?: number;
+        swapKind: SwapKind;
+        tokenPrices: Map<string, number>;
+        minLimitThresholdUSD: number;
     }) {
         this.poolAddressMap = new Map();
-        this.nodes = new Map();
+        this.nodes = new Set();
         this.edges = new Map();
 
         this.buildPoolAddressMap(pools);
@@ -58,13 +55,13 @@ export class PathGraphBeam {
 
     // Since the path combinations here can get quite large, we use configurable parameters
     // to enforce upper limits across several dimensions, defined in the pathConfig.
-    // (a) maxDepth - the max depth of the traversal (length of token path), defaults to 7.
-    // (b) maxNonBoostedPathDepth - the max depth for any path that does not contain a phantom bpt.
-    // (c) maxNonBoostedHopTokensInBoostedPath - The max number of non boosted hop tokens
-    // allowed in a boosted path.
+    // (a) maxDepth - the max depth of the traversal (length of token path), defaults to 4.
+    // (b) maxTokenPaths - the max number of token paths to search for, defaults to 50.
+    // (c) maxBuffersInPath - the max number of buffers in a path, defaults to 5.
     // (d) approxPathsToReturn - search for up to this many paths. Since all paths for a single traversal
     // are added, its possible that the amount returned is larger than this number.
-    // (e) poolIdsToInclude - Only include paths with these poolIds (optional)
+    // (e) minSwapAmountRatio - the min swap amount ratio, defaults to 0.5.
+    // (f) poolIdsToInclude - Only include paths with these poolIds (optional)
 
     // Additionally, we impose the following requirements for a path to be considered valid
     // (a) It does not visit the same token twice
@@ -82,13 +79,6 @@ export class PathGraphBeam {
         swapKind: SwapKind;
         graphTraversalConfig?: Partial<PathGraphTraversalConfig>;
     }): PathLocal[] {
-        // early checks
-        const hasEdgeWithTokenIn = this.edges.has(tokenIn.wrapped);
-        const hasEdgeWithTokenOut = this.edges.has(tokenOut.wrapped);
-        if (!hasEdgeWithTokenIn || !hasEdgeWithTokenOut) {
-            return [];
-        }
-
         const isHyperEvm = tokenIn.chainId === 999;
 
         // apply defaults, allowing caller override whatever they'd like
@@ -105,42 +95,53 @@ export class PathGraphBeam {
         // Calculate minimum limit threshold based on swap amount and ratio
         const minLimitThreshold = (swapAmount.amount * BigInt(Math.floor(config.minSwapAmountRatio * 100))) / 100n;
 
-        // time findAllValidTokenPaths
-        const findAllValidTokenPathsStart = performance.now();
         const tokenPaths = this.findAllValidTokenPaths({
             tokenIn: tokenIn.wrapped,
             tokenOut: tokenOut.wrapped,
             config,
         });
-        const findAllValidTokenPathsEnd = performance.now();
-        console.log(
-            `SOR:findAllValidTokenPaths: ${(findAllValidTokenPathsEnd - findAllValidTokenPathsStart).toFixed(2)}ms`,
-        );
-        console.log('tokenPaths found -> ', tokenPaths.length);
 
-        const paths: PathGraphEdgeData[][] = [];
+        // Step 1: Generate all candidate combinations across all token paths
+        const allCandidates: Array<{
+            tokenPath: string[];
+            perSegmentEdges: PathGraphEdgeData[][];
+            candidates: { ranks: number[]; boundNL: bigint }[];
+        }> = [];
 
-        // Use the new greedy best-first approach for each token path
-        const expandTokenPathWithBestRanksStart = performance.now();
         for (const tokenPath of tokenPaths) {
-            const expandedPaths = this.expandTokenPathWithBestRanks({
-                tokenPath,
-                swapKind,
-                minLimitThreshold,
-                approxPathsToReturn: config.approxPathsToReturn,
-                config,
-            });
+            const segmentCount = tokenPath.length - 1;
+            if (segmentCount <= 0) continue;
 
-            for (const path of expandedPaths) {
-                paths.push(path);
+            // Gather candidate edges per segment (already sorted by normalizedLiquidity desc)
+            const perSegmentEdges: PathGraphEdgeData[][] = new Array(segmentCount);
+            for (let i = 0; i < segmentCount; i++) {
+                const edges = this.edges.get(tokenPath[i])?.get(tokenPath[i + 1]);
+                if (!edges) continue; // path cannot be built
+                perSegmentEdges[i] = edges;
+            }
+
+            // Generate all combinations for this token path using beam search
+            const candidates = this.selectTopCandidatesPerTokenPath(perSegmentEdges, config.approxPathsToReturn);
+
+            if (candidates.length > 0) {
+                allCandidates.push({
+                    tokenPath,
+                    perSegmentEdges,
+                    candidates,
+                });
             }
         }
-        const expandTokenPathWithBestRanksEnd = performance.now();
-        console.log(
-            `SOR:expandTokenPathWithBestRanks: ${(
-                expandTokenPathWithBestRanksEnd - expandTokenPathWithBestRanksStart
-            ).toFixed(2)}ms`,
+
+        const flattenedCandidates = allCandidates.flatMap(({ tokenPath, perSegmentEdges, candidates }) =>
+            candidates.map((candidate) => ({
+                tokenPath,
+                perSegmentEdges,
+                candidate,
+            })),
         );
+
+        // Step 2: Expand and validate the selected candidates
+        const paths = this.expandAndValidateCandidates(flattenedCandidates, swapKind, minLimitThreshold, config);
 
         return paths.map((path) => {
             const pathTokens: Token[] = [...path.map((segment) => segment.tokenOut)];
@@ -223,16 +224,6 @@ export class PathGraphBeam {
         }
     }
 
-    private addNode(token: Token): void {
-        this.nodes.set(token.wrapped, {
-            isPhantomBpt: !!this.poolAddressMap.get(token.wrapped),
-        });
-
-        if (!this.edges.has(token.wrapped)) {
-            this.edges.set(token.wrapped, new Map());
-        }
-    }
-
     // Build edge properties including optional limitUSD using tokenPrices for the given swapKind
     private buildEdgeProps({
         pool,
@@ -268,6 +259,14 @@ export class PathGraphBeam {
         };
     }
 
+    private addNode(token: Token): void {
+        this.nodes.add(token.wrapped);
+
+        if (!this.edges.has(token.wrapped)) {
+            this.edges.set(token.wrapped, new Map());
+        }
+    }
+
     /**
      * Adds a directed edge from a source vertex to a destination
      */
@@ -278,8 +277,8 @@ export class PathGraphBeam {
         edgeProps: PathGraphEdgeData;
         maxPathsPerTokenPair: number;
     }): void {
-        const tokenInVertex = this.nodes.get(edgeProps.tokenIn.wrapped);
-        const tokenOutVertex = this.nodes.get(edgeProps.tokenOut.wrapped);
+        const tokenInVertex = this.nodes.has(edgeProps.tokenIn.wrapped);
+        const tokenOutVertex = this.nodes.has(edgeProps.tokenOut.wrapped);
         const tokenInNode = this.edges.get(edgeProps.tokenIn.wrapped);
 
         if (!tokenInVertex || !tokenOutVertex || !tokenInNode) {
@@ -288,7 +287,6 @@ export class PathGraphBeam {
 
         const existingEdges = tokenInNode.get(edgeProps.tokenOut.wrapped) || [];
 
-        //TODO: ideally we don't call sort every time, this isn't performant
         const sorted = [...existingEdges, edgeProps].sort((a, b) =>
             a.normalizedLiquidity > b.normalizedLiquidity ? -1 : 1,
         );
@@ -338,7 +336,17 @@ export class PathGraphBeam {
         return results;
     }
 
-    private isValidPath({ path, config }: { path: PathGraphEdgeData[]; config: PathGraphTraversalConfig }) {
+    private isValidPath({
+        path,
+        config,
+        swapKind,
+        minLimitThreshold,
+    }: {
+        path: PathGraphEdgeData[];
+        config: PathGraphTraversalConfig;
+        swapKind: SwapKind;
+        minLimitThreshold: bigint;
+    }) {
         const poolIdsInPath = path.map((segment) => segment.pool.id);
 
         if (config.poolIdsToInclude) {
@@ -361,44 +369,13 @@ export class PathGraphBeam {
             return false;
         }
 
+        if (this.getLimitAmountSwapForPath(path, swapKind) < minLimitThreshold) {
+            return false;
+        }
+
         return true;
     }
 
-    private getIdForPath(path: PathGraphEdgeData[]): string {
-        let id = '';
-
-        for (const segment of path) {
-            if (id.length > 0) {
-                id += '_';
-            }
-
-            id += `${segment.pool.id}-${segment.tokenIn}-${segment.tokenOut}`;
-        }
-
-        return id;
-    }
-
-    // please add a description to how this function works internally
-    /**
-     * Calculates the maximum feasible swap size for a given path.
-     * @param path - The path to calculate the limit for.
-     * @param swapKind - The type of swap to calculate the limit for.
-     * @returns The maximum feasible swap size for the path.
-     *
-     * This function works by starting with the last segment of the path and working backwards.
-     * It calculates the limit for the last segment using the getLimitAmountSwap method.
-     * Then, it iterates through the remaining segments, calculating the limit for each segment.
-     * The limit for each segment is the minimum of the limit for the previous segment and the limit for the current segment.
-     * If the limit for the current segment is greater than the limit for the previous segment, it means that the current segment is the bottleneck.
-     * In this case, the function calculates the limit for the current segment by pulling the limit from the previous segment.
-     * The function returns the limit for the first segment.
-     *
-     * This function is used to calculate the limit for a given path.
-     * The limit is used to determine if a path is valid.
-     * The limit is also used to determine the best path to use.
-     *
-     *
-     */
     private getLimitAmountSwapForPath(path: PathGraphEdgeData[], swapKind: SwapKind): bigint {
         let limit = path[path.length - 1].pool.getLimitAmountSwap(
             path[path.length - 1].tokenIn,
@@ -435,46 +412,22 @@ export class PathGraphBeam {
     }
 
     /**
-     * Expands a token path using a greedy best-first approach with early limit checking.
-     * Instead of exploring all rank combinations, this prioritizes highest liquidity options
-     * and stops when paths meet the minimum limit threshold.
+     * Generates candidate combinations for a single token path using beam search.
+     *
+     * @param perSegmentEdges - Array of edge arrays for each segment
+     * @param beamWidth - Maximum number of candidates to keep
+     * @returns Array of candidate rank combinations
      */
-    /**
-     * Beam-search over ranks per segment.
-     * - Precompute a cheap optimistic bound per edge using getLimitAmountSwap (cached).
-     * - Expand only top candidates by that bound before evaluating expensive full-path limit.
-     * - Keeps at most approxPathsToReturn candidates throughout.
-     */
-    private expandTokenPathWithBestRanks({
-        tokenPath,
-        swapKind,
-        minLimitThreshold,
-        approxPathsToReturn,
-        config,
-    }: {
-        tokenPath: string[];
-        swapKind: SwapKind;
-        minLimitThreshold: bigint;
-        approxPathsToReturn: number;
-        config: PathGraphTraversalConfig;
-    }): PathGraphEdgeData[][] {
-        const segmentCount = tokenPath.length - 1;
+    private selectTopCandidatesPerTokenPath(
+        perSegmentEdges: PathGraphEdgeData[][],
+        beamWidth: number,
+    ): { ranks: number[]; boundNL: bigint }[] {
+        const segmentCount = perSegmentEdges.length;
         if (segmentCount <= 0) return [];
-
-        // Gather candidate edges per segment (already sorted by normalizedLiquidity desc).
-        const perSegmentEdges: PathGraphEdgeData[][] = new Array(segmentCount);
-        for (let i = 0; i < segmentCount; i++) {
-            const edges = this.edges.get(tokenPath[i])?.get(tokenPath[i + 1]);
-            if (!edges) return []; // path cannot be built
-            perSegmentEdges[i] = edges;
-        }
 
         // Beam search: keep only the top K partial combos by bottleneck normalizedLiquidity
         type Partial = { ranks: number[]; boundNL: bigint };
         let partials: Partial[] = [{ ranks: [], boundNL: 0n }];
-
-        // Make the beam wider than the final number to ensure diversity
-        const beamWidth = Math.max(approxPathsToReturn * 2, approxPathsToReturn);
 
         for (let seg = 0; seg < segmentCount; seg++) {
             const edges = perSegmentEdges[seg];
@@ -500,23 +453,75 @@ export class PathGraphBeam {
             partials = next.slice(0, beamWidth);
         }
 
-        // Evaluate real limits only for the finalists and filter by threshold
-        // This is the expensive part; we limited it by beamWidth.
-        const pathsWithRealLimit: { path: PathGraphEdgeData[]; limit: bigint }[] = [];
+        return partials;
+    }
 
-        for (const p of partials) {
+    /**
+     * Applies global beam search to select the top candidates across all token paths.
+     *
+     * This method aggregates all candidates from different token paths and applies beam search
+     * globally to select the most promising candidates based on bottleneck normalized liquidity.
+     *
+     * @param allCandidates - Array of candidate groups from all token paths
+     * @param beamWidth - Maximum number of candidates to select globally
+     * @returns Array of top candidates with their associated data
+     */
+    private selectTopCandidatesGlobally(
+        allCandidates: Array<{
+            tokenPath: string[];
+            perSegmentEdges: PathGraphEdgeData[][];
+            candidates: { ranks: number[]; boundNL: bigint }[];
+        }>,
+        beamWidth: number,
+    ): Array<{
+        tokenPath: string[];
+        perSegmentEdges: PathGraphEdgeData[][];
+        candidate: { ranks: number[]; boundNL: bigint };
+    }> {
+        // Flatten all candidates with their associated data
+        const flattenedCandidates = allCandidates.flatMap(({ tokenPath, perSegmentEdges, candidates }) =>
+            candidates.map((candidate) => ({
+                tokenPath,
+                perSegmentEdges,
+                candidate,
+            })),
+        );
+
+        // Sort by bottleneck normalized liquidity (descending) and take top K
+        flattenedCandidates.sort((a, b) => (a.candidate.boundNL < b.candidate.boundNL ? 1 : -1));
+
+        return flattenedCandidates.slice(0, beamWidth);
+    }
+
+    /**
+     * Expands and validates the selected candidates to return final paths.
+     *
+     * This method takes the top candidates selected by global beam search and performs
+     * the expensive path expansion and validation only for these candidates.
+     *
+     * @param topCandidates - Array of top candidates with their associated data
+     * @param swapKind - Type of swap (exact input or exact output)
+     * @param minLimitThreshold - Minimum swap limit threshold
+     * @param config - Path graph traversal configuration
+     * @returns Array of valid paths that meet the criteria
+     */
+    private expandAndValidateCandidates(
+        topCandidates: Array<{
+            tokenPath: string[];
+            perSegmentEdges: PathGraphEdgeData[][];
+            candidate: { ranks: number[]; boundNL: bigint };
+        }>,
+        swapKind: SwapKind,
+        minLimitThreshold: bigint,
+        config: PathGraphTraversalConfig,
+    ): PathGraphEdgeData[][] {
+        const validPaths: PathGraphEdgeData[][] = [];
+
+        for (const { perSegmentEdges, candidate } of topCandidates) {
             try {
-                const path = this.expandTokenPathWithRanks({ perSegmentEdges, ranks: p.ranks });
-                if (!this.isValidPath({ path, config })) {
-                    continue;
-                }
-                const limit = this.getLimitAmountSwapForPath(path, swapKind);
-                if (limit >= minLimitThreshold) {
-                    pathsWithRealLimit.push({ path, limit });
-                    if (pathsWithRealLimit.length >= approxPathsToReturn) {
-                        // We can stop early if we already have enough candidates meeting the threshold.
-                        break;
-                    }
+                const path = this.expandTokenPathWithRanks({ perSegmentEdges, ranks: candidate.ranks });
+                if (this.isValidPath({ path, config, swapKind, minLimitThreshold })) {
+                    validPaths.push(path);
                 }
             } catch {
                 // getLimitAmountSwapForPath failed (likely due to trade/wrap amount too small)
@@ -524,7 +529,7 @@ export class PathGraphBeam {
             }
         }
 
-        return pathsWithRealLimit.map((x) => x.path);
+        return validPaths;
     }
 
     /**

--- a/modules/sor/lib/pathGraph/pathGraph-beam.ts
+++ b/modules/sor/lib/pathGraph/pathGraph-beam.ts
@@ -82,13 +82,19 @@ export class PathGraphBeam {
         swapKind: SwapKind;
         graphTraversalConfig?: Partial<PathGraphTraversalConfig>;
     }): PathLocal[] {
+        // early checks
+        const hasEdgeWithTokenIn = this.edges.has(tokenIn.wrapped);
+        const hasEdgeWithTokenOut = this.edges.has(tokenOut.wrapped);
+        if (!hasEdgeWithTokenIn || !hasEdgeWithTokenOut) {
+            return [];
+        }
+
         const isHyperEvm = tokenIn.chainId === 999;
 
         // apply defaults, allowing caller override whatever they'd like
         const config: PathGraphTraversalConfig = {
-            maxDepth: 6,
-            maxNonBoostedPathDepth: 3,
-            maxNonBoostedHopTokensInBoostedPath: 2,
+            maxDepth: 4,
+            maxTokenPaths: 50,
             maxBuffersInPath: isHyperEvm ? 2 : 5, // limited only on HyperEvm due to gas cost limits on small blocks - virtually unlimited otherwise
             approxPathsToReturn: 20, // Default to 20 - likely won't be reached, but acts as a bound to the computation if needed
             maxRanksPerSegment: 2, // Default 2 for diversity
@@ -99,33 +105,42 @@ export class PathGraphBeam {
         // Calculate minimum limit threshold based on swap amount and ratio
         const minLimitThreshold = (swapAmount.amount * BigInt(Math.floor(config.minSwapAmountRatio * 100))) / 100n;
 
+        // time findAllValidTokenPaths
+        const findAllValidTokenPathsStart = performance.now();
         const tokenPaths = this.findAllValidTokenPaths({
-            token: tokenIn.wrapped,
             tokenIn: tokenIn.wrapped,
             tokenOut: tokenOut.wrapped,
             config,
-            tokenPath: [tokenIn.wrapped],
-        }).sort((a, b) => (a.length < b.length ? -1 : 1));
+        });
+        const findAllValidTokenPathsEnd = performance.now();
+        console.log(
+            `SOR:findAllValidTokenPaths: ${(findAllValidTokenPathsEnd - findAllValidTokenPathsStart).toFixed(2)}ms`,
+        );
+        console.log('tokenPaths found -> ', tokenPaths.length);
 
         const paths: PathGraphEdgeData[][] = [];
-        const selectedPathIds: string[] = [];
 
         // Use the new greedy best-first approach for each token path
+        const expandTokenPathWithBestRanksStart = performance.now();
         for (const tokenPath of tokenPaths) {
             const expandedPaths = this.expandTokenPathWithBestRanks({
                 tokenPath,
                 swapKind,
                 minLimitThreshold,
                 approxPathsToReturn: config.approxPathsToReturn,
+                config,
             });
 
             for (const path of expandedPaths) {
-                if (this.isValidPath({ path, seenPoolAddresses: [], selectedPathIds, config })) {
-                    selectedPathIds.push(this.getIdForPath(path));
-                    paths.push(path);
-                }
+                paths.push(path);
             }
         }
+        const expandTokenPathWithBestRanksEnd = performance.now();
+        console.log(
+            `SOR:expandTokenPathWithBestRanks: ${(
+                expandTokenPathWithBestRanksEnd - expandTokenPathWithBestRanksStart
+            ).toFixed(2)}ms`,
+        );
 
         return paths.map((path) => {
             const pathTokens: Token[] = [...path.map((segment) => segment.tokenOut)];
@@ -189,16 +204,20 @@ export class PathGraphBeam {
             for (const tokenIn of tokens) {
                 for (const tokenOut of tokens) {
                     if (tokenIn === tokenOut) continue;
-                    const edgeProps = this.buildEdgeProps({ pool, tokenIn, tokenOut, swapKind, tokenPrices });
-                    // Skip edges whose USD limit is known and below threshold; allow undefined to pass
-                    if (
-                        minLimitThresholdUSD !== undefined &&
-                        edgeProps.limitUSD !== undefined &&
-                        edgeProps.limitUSD < minLimitThresholdUSD
-                    ) {
-                        continue;
+                    try {
+                        const edgeProps = this.buildEdgeProps({ pool, tokenIn, tokenOut, swapKind, tokenPrices });
+                        // Skip edges whose USD limit is known and below threshold; allow undefined to pass
+                        if (
+                            minLimitThresholdUSD !== undefined &&
+                            edgeProps.limitUSD !== undefined &&
+                            edgeProps.limitUSD < minLimitThresholdUSD
+                        ) {
+                            continue;
+                        }
+                        this.addEdge({ edgeProps, maxPathsPerTokenPair });
+                    } catch (error) {
+                        // leave edge undefined if anything fails
                     }
-                    this.addEdge({ edgeProps, maxPathsPerTokenPair });
                 }
             }
         }
@@ -230,16 +249,12 @@ export class PathGraphBeam {
     }): PathGraphEdgeData {
         let limitUSD: number | undefined = undefined;
         if (swapKind && tokenPrices) {
-            try {
-                const limit = pool.getLimitAmountSwap(tokenIn, tokenOut, swapKind);
-                const priceToken = (swapKind as any) === SwapKind.GivenIn ? tokenIn : tokenOut;
-                const price = tokenPrices.get(priceToken.wrapped.toLowerCase());
-                if (price !== undefined) {
-                    const amount = Number(formatUnits(limit, priceToken.decimals));
-                    limitUSD = amount * price;
-                }
-            } catch (_e) {
-                // leave limitUSD undefined if anything fails
+            const limit = pool.getLimitAmountSwap(tokenIn, tokenOut, swapKind);
+            const priceToken = (swapKind as any) === SwapKind.GivenIn ? tokenIn : tokenOut;
+            const price = tokenPrices.get(priceToken.wrapped.toLowerCase());
+            if (price !== undefined) {
+                const amount = Number(formatUnits(limit, priceToken.decimals));
+                limitUSD = amount * price;
             }
         }
 
@@ -284,74 +299,38 @@ export class PathGraphBeam {
         );
     }
 
-    private findAllValidTokenPaths(args: {
-        token: string;
+    private findAllValidTokenPaths({
+        tokenIn,
+        tokenOut,
+        config,
+    }: {
         tokenIn: string;
         tokenOut: string;
-        tokenPath: string[]; // unused in refactor; we always start from tokenIn
         config: PathGraphTraversalConfig;
     }): string[][] {
-        const { tokenIn, tokenOut, config } = args;
-
         const results: string[][] = [];
-        if (tokenIn === tokenOut) return [[tokenIn]];
+        const queue: { node: string; path: string[] }[] = [{ node: tokenIn, path: [tokenIn] }];
 
-        // Use BFS queue instead of DFS stack
-        type QueueItem = {
-            node: string;
-            path: string[];
-            numStandardHopTokens: number;
-        };
-
-        const queue: QueueItem[] = [
-            {
-                node: tokenIn,
-                path: [tokenIn],
-                numStandardHopTokens: 0,
-            },
-        ];
-
-        // Respect the "approxPathsToReturn" as an upper bound (per docs).
-        const maxTokenPaths = Math.max(1, config.approxPathsToReturn);
-
-        while (queue.length > 0 && results.length < maxTokenPaths) {
-            const { node, path, numStandardHopTokens } = queue.shift()!;
+        while (queue.length > 0 && results.length < config.maxTokenPaths) {
+            const { node, path } = queue.shift()!;
 
             const neighbors = this.edges.get(node);
             if (!neighbors) continue;
 
             for (const [neighbor] of neighbors) {
-                // No revisiting the same token
+                // small hot-path optimization: check length bounds before cloning array
+                if (path.length + 1 > config.maxDepth) continue;
+
+                // no cycles
                 if (path.includes(neighbor)) continue;
-
-                const nextDepth = path.length + 1;
-                if (nextDepth > config.maxDepth) continue;
-
-                // Count hop tokens excluding endpoints
-                const isHopToken = neighbor !== tokenIn && neighbor !== tokenOut;
-                const nextNumStandardHopTokens = numStandardHopTokens + (isHopToken ? 1 : 0);
-
-                if (
-                    nextDepth > config.maxNonBoostedPathDepth &&
-                    nextNumStandardHopTokens > config.maxNonBoostedHopTokensInBoostedPath
-                ) {
-                    continue;
-                }
 
                 const newPath = [...path, neighbor];
 
                 if (neighbor === tokenOut) {
-                    // Complete path checks
-                    if (nextDepth > config.maxNonBoostedPathDepth) continue;
                     results.push(newPath);
-                    if (results.length >= maxTokenPaths) break;
                 } else {
-                    // Add to queue for further exploration (BFS)
-                    queue.push({
-                        node: neighbor,
-                        path: newPath,
-                        numStandardHopTokens: nextNumStandardHopTokens,
-                    });
+                    // push longer path into queue
+                    queue.push({ node: neighbor, path: newPath });
                 }
             }
         }
@@ -359,19 +338,8 @@ export class PathGraphBeam {
         return results;
     }
 
-    private isValidPath({
-        path,
-        seenPoolAddresses,
-        selectedPathIds,
-        config,
-    }: {
-        path: PathGraphEdgeData[];
-        seenPoolAddresses: string[];
-        selectedPathIds: string[];
-        config: PathGraphTraversalConfig;
-    }) {
+    private isValidPath({ path, config }: { path: PathGraphEdgeData[]; config: PathGraphTraversalConfig }) {
         const poolIdsInPath = path.map((segment) => segment.pool.id);
-        const uniquePools = [...new Set(poolIdsInPath)];
 
         if (config.poolIdsToInclude) {
             for (const poolId of poolIdsInPath) {
@@ -383,22 +351,12 @@ export class PathGraphBeam {
         }
 
         //dont include any path that hops through the same pool twice
+        const uniquePools = [...new Set(poolIdsInPath)];
         if (uniquePools.length !== poolIdsInPath.length) {
             return false;
         }
 
-        for (const segment of path) {
-            if (seenPoolAddresses.includes(segment.pool.address)) {
-                //this path contains a pool that has already been used
-                return false;
-            }
-        }
-
-        //this is a duplicate path
-        if (selectedPathIds.includes(this.getIdForPath(path))) {
-            return false;
-        }
-
+        //dont include any path that has more than maxBuffersInPath buffers
         if (path.filter((segment) => segment.isBuffer).length > config.maxBuffersInPath) {
             return false;
         }
@@ -492,11 +450,13 @@ export class PathGraphBeam {
         swapKind,
         minLimitThreshold,
         approxPathsToReturn,
+        config,
     }: {
         tokenPath: string[];
         swapKind: SwapKind;
         minLimitThreshold: bigint;
         approxPathsToReturn: number;
+        config: PathGraphTraversalConfig;
     }): PathGraphEdgeData[][] {
         const segmentCount = tokenPath.length - 1;
         if (segmentCount <= 0) return [];
@@ -514,7 +474,7 @@ export class PathGraphBeam {
         let partials: Partial[] = [{ ranks: [], boundNL: 0n }];
 
         // Make the beam wider than the final number to ensure diversity
-        const beamWidth = Math.max(approxPathsToReturn * 10, approxPathsToReturn);
+        const beamWidth = Math.max(approxPathsToReturn * 2, approxPathsToReturn);
 
         for (let seg = 0; seg < segmentCount; seg++) {
             const edges = perSegmentEdges[seg];
@@ -547,6 +507,9 @@ export class PathGraphBeam {
         for (const p of partials) {
             try {
                 const path = this.expandTokenPathWithRanks({ perSegmentEdges, ranks: p.ranks });
+                if (!this.isValidPath({ path, config })) {
+                    continue;
+                }
                 const limit = this.getLimitAmountSwapForPath(path, swapKind);
                 if (limit >= minLimitThreshold) {
                     pathsWithRealLimit.push({ path, limit });

--- a/modules/sor/lib/pathGraph/pathGraph-beam.ts
+++ b/modules/sor/lib/pathGraph/pathGraph-beam.ts
@@ -5,7 +5,7 @@ import { PathLocal } from '../path';
 
 const DEFAULT_MAX_PATHS_PER_TOKEN_PAIR = 10;
 
-export class PathGraph {
+export class PathGraphBeam {
     private nodes: Map<string, { isPhantomBpt: boolean }>;
     private edges: Map<string, Map<string, PathGraphEdgeData[]>>;
     private poolAddressMap: Map<string, BasePool>;

--- a/modules/sor/lib/pathGraph/pathGraph-proper-bfs.ts
+++ b/modules/sor/lib/pathGraph/pathGraph-proper-bfs.ts
@@ -5,7 +5,7 @@ import { PathLocal } from '../path';
 
 const DEFAULT_MAX_PATHS_PER_TOKEN_PAIR = 10;
 
-export class PathGraph {
+export class PathGraphBfs {
     private nodes: Map<string, { isPhantomBpt: boolean }>;
     private edges: Map<string, Map<string, PathGraphEdgeData[]>>;
     private poolAddressMap: Map<string, BasePool>;

--- a/modules/sor/lib/pathGraph/pathGraph-proper-bfs.ts
+++ b/modules/sor/lib/pathGraph/pathGraph-proper-bfs.ts
@@ -1,9 +1,10 @@
+import { formatUnits } from 'viem';
 import { Address, SwapKind, Token, TokenAmount } from '@balancer/sdk';
 import { PathGraphEdgeData, PathGraphTraversalConfig } from './pathGraphTypes';
 import { BasePool } from '../poolsV2/basePool';
 import { PathLocal } from '../path';
 
-const DEFAULT_MAX_PATHS_PER_TOKEN_PAIR = 10;
+const DEFAULT_MAX_PATHS_PER_TOKEN_PAIR = 2;
 
 export class PathGraphBfs {
     private nodes: Map<string, { isPhantomBpt: boolean }>;
@@ -27,10 +28,16 @@ export class PathGraphBfs {
         pools,
         maxPathsPerTokenPair = DEFAULT_MAX_PATHS_PER_TOKEN_PAIR,
         enableAddRemoveLiquidityPaths,
+        swapKind,
+        tokenPrices,
+        minLimitThresholdUSD,
     }: {
         pools: BasePool[];
         maxPathsPerTokenPair?: number;
         enableAddRemoveLiquidityPaths: boolean;
+        swapKind?: SwapKind;
+        tokenPrices?: Map<string, number>;
+        minLimitThresholdUSD?: number;
     }) {
         this.poolAddressMap = new Map();
         this.nodes = new Map();
@@ -41,7 +48,14 @@ export class PathGraphBfs {
 
         this.addAllTokensAsGraphNodes({ pools, enableAddRemoveLiquidityPaths });
 
-        this.addTokenPairsAsGraphEdges({ pools, maxPathsPerTokenPair, enableAddRemoveLiquidityPaths });
+        this.addTokenPairsAsGraphEdges({
+            pools,
+            maxPathsPerTokenPair,
+            enableAddRemoveLiquidityPaths,
+            swapKind,
+            tokenPrices,
+            minLimitThresholdUSD,
+        });
     }
 
     // Since the path combinations here can get quite large, we use configurable parameters
@@ -63,12 +77,14 @@ export class PathGraphBfs {
         swapAmount,
         swapKind,
         graphTraversalConfig,
+        minLimitThresholdUSD,
     }: {
         tokenIn: Token;
         tokenOut: Token;
         swapAmount: TokenAmount;
         swapKind: SwapKind;
         graphTraversalConfig?: Partial<PathGraphTraversalConfig>;
+        minLimitThresholdUSD?: number;
     }): PathLocal[] {
         const isHyperEvm = tokenIn.chainId === 999;
 
@@ -104,7 +120,6 @@ export class PathGraphBfs {
                 tokenPath,
                 swapKind,
                 minLimitThreshold,
-                maxRanksPerSegment: config.maxRanksPerSegment,
                 approxPathsToReturn: config.approxPathsToReturn,
             });
 
@@ -116,7 +131,7 @@ export class PathGraphBfs {
             }
         }
 
-        return this.sortAndFilterPaths(paths).map((path) => {
+        return paths.map((path) => {
             const pathTokens: Token[] = [...path.map((segment) => segment.tokenOut)];
             pathTokens.unshift(tokenIn);
             pathTokens[pathTokens.length - 1] = tokenOut;
@@ -127,44 +142,6 @@ export class PathGraphBfs {
                 path.map((segment) => segment.isBuffer),
             );
         });
-    }
-
-    private sortAndFilterPaths(paths: PathGraphEdgeData[][]): PathGraphEdgeData[][] {
-        const pathsWithLimits = paths
-            .map((path) => {
-                try {
-                    const limit = this.getLimitAmountSwapForPath(path, SwapKind.GivenIn);
-                    return { path, limit };
-                } catch (_e) {
-                    console.log('Error getting limit for path', path.map((p) => p.pool.id).join(' -> '));
-                    return undefined;
-                }
-            })
-            .filter((path): path is { path: PathGraphEdgeData[]; limit: bigint } => !!path)
-            .sort((a, b) => (a.limit < b.limit ? 1 : -1));
-
-        const filtered: PathGraphEdgeData[][] = [];
-
-        // Remove any paths with duplicate pools. since the paths are now sorted by limit,
-        // selecting the first path will always be the optimal.
-        for (const { path } of pathsWithLimits) {
-            let seenPools: string[] = [];
-            let isValid = true;
-
-            for (const segment of path) {
-                if (seenPools.includes(segment.pool.id)) {
-                    isValid = false;
-                    break;
-                }
-            }
-
-            if (isValid) {
-                filtered.push(path);
-                seenPools = [...seenPools, ...path.map((segment) => segment.pool.id)];
-            }
-        }
-
-        return filtered;
     }
 
     private buildPoolAddressMap(pools: BasePool[]) {
@@ -197,10 +174,16 @@ export class PathGraphBfs {
         pools,
         maxPathsPerTokenPair,
         enableAddRemoveLiquidityPaths,
+        swapKind,
+        tokenPrices,
+        minLimitThresholdUSD,
     }: {
         pools: BasePool[];
         maxPathsPerTokenPair: number;
         enableAddRemoveLiquidityPaths: boolean;
+        swapKind?: SwapKind;
+        tokenPrices?: Map<string, number>;
+        minLimitThresholdUSD?: number;
     }) {
         for (const pool of pools) {
             const tokens = [...pool.tokens.map((t) => t.token)];
@@ -210,19 +193,58 @@ export class PathGraphBfs {
             for (const tokenIn of tokens) {
                 for (const tokenOut of tokens) {
                     if (tokenIn === tokenOut) continue;
-                    this.addEdge({
-                        edgeProps: {
-                            pool,
-                            tokenIn,
-                            tokenOut,
-                            normalizedLiquidity: pool.getNormalizedLiquidity(tokenIn, tokenOut),
-                            isBuffer: pool.poolType === 'Buffer',
-                        },
-                        maxPathsPerTokenPair,
-                    });
+                    const edgeProps = this.buildEdgeProps({ pool, tokenIn, tokenOut, swapKind, tokenPrices });
+                    // Skip edges whose USD limit is known and below threshold; allow undefined to pass
+                    if (
+                        minLimitThresholdUSD !== undefined &&
+                        edgeProps.limitUSD !== undefined &&
+                        edgeProps.limitUSD < minLimitThresholdUSD
+                    ) {
+                        continue;
+                    }
+                    this.addEdge({ edgeProps, maxPathsPerTokenPair });
                 }
             }
         }
+    }
+
+    // Build edge properties including optional limitUSD using tokenPrices for the given swapKind
+    private buildEdgeProps({
+        pool,
+        tokenIn,
+        tokenOut,
+        swapKind,
+        tokenPrices,
+    }: {
+        pool: BasePool;
+        tokenIn: Token;
+        tokenOut: Token;
+        swapKind?: SwapKind;
+        tokenPrices?: Map<string, number>;
+    }): PathGraphEdgeData {
+        let limitUSD: number | undefined = undefined;
+        if (swapKind && tokenPrices) {
+            try {
+                const limit = pool.getLimitAmountSwap(tokenIn, tokenOut, swapKind);
+                const priceToken = (swapKind as any) === SwapKind.GivenIn ? tokenIn : tokenOut;
+                const price = tokenPrices.get(priceToken.wrapped.toLowerCase());
+                if (price !== undefined) {
+                    const amount = Number(formatUnits(limit, priceToken.decimals));
+                    limitUSD = amount * price;
+                }
+            } catch (_e) {
+                // leave limitUSD undefined if anything fails
+            }
+        }
+
+        return {
+            pool,
+            tokenIn,
+            tokenOut,
+            normalizedLiquidity: pool.getNormalizedLiquidity(tokenIn, tokenOut),
+            isBuffer: pool.poolType === 'Buffer',
+            limitUSD,
+        };
     }
 
     private addNode(token: Token): void {
@@ -253,19 +275,15 @@ export class PathGraphBfs {
             throw new Error('Attempting to add invalid edge');
         }
 
-        const hasPhantomBpt = tokenInVertex.isPhantomBpt || tokenOutVertex.isPhantomBpt;
         const existingEdges = tokenInNode.get(edgeProps.tokenOut.wrapped) || [];
 
-        //TODO: ideally we don't call sort every time, this isn't performant
         const sorted = [...existingEdges, edgeProps].sort((a, b) =>
             a.normalizedLiquidity > b.normalizedLiquidity ? -1 : 1,
         );
 
-        // TODO: double check if the hasPhantomBpt issue is not affecting v3 liquidity more frequently (considering all
-        // pools have their BPT artificially added so we consider them for add/remove liquidity steps)
         tokenInNode.set(
             edgeProps.tokenOut.wrapped,
-            sorted.length > maxPathsPerTokenPair && !hasPhantomBpt ? sorted.slice(0, maxPathsPerTokenPair) : sorted,
+            sorted.length > maxPathsPerTokenPair ? sorted.slice(0, maxPathsPerTokenPair) : sorted,
         );
     }
 
@@ -457,13 +475,11 @@ export class PathGraphBfs {
         tokenPath,
         swapKind,
         minLimitThreshold,
-        maxRanksPerSegment,
         approxPathsToReturn,
     }: {
         tokenPath: string[];
         swapKind: SwapKind;
         minLimitThreshold: bigint;
-        maxRanksPerSegment: number;
         approxPathsToReturn: number;
     }): PathGraphEdgeData[][] {
         const results: PathGraphEdgeData[][] = [];
@@ -481,26 +497,21 @@ export class PathGraphBfs {
             let path: PathGraphEdgeData[];
             try {
                 path = this.expandTokenPathWithRanks({ tokenPath, ranks });
-            } catch {
-                continue; // skip invalid rank combination
-            }
-
-            try {
                 const limit = this.getLimitAmountSwapForPath(path, swapKind);
                 if (limit >= minLimitThreshold) {
                     results.push(path);
+                }
 
-                    // enqueue "neighboring" rank choices — but bounded by maxRanksPerSegment
-                    for (let i = 0; i < ranks.length; i++) {
-                        if (ranks[i] + 1 < maxRanksPerSegment && ranks[i] + 1 < this.maxPathsPerTokenPair) {
-                            const newRanks = [...ranks];
-                            newRanks[i]++;
-                            queue.push(newRanks);
-                        }
+                // enqueue "neighboring" rank choices — but bounded by maxRanksPerSegment
+                for (let i = 0; i < ranks.length; i++) {
+                    if (ranks[i] + 1 < this.maxPathsPerTokenPair) {
+                        const newRanks = [...ranks];
+                        newRanks[i]++;
+                        queue.push(newRanks);
                     }
                 }
             } catch {
-                // If limit computation fails, just skip
+                continue; // skip invalid rank combination
             }
         }
 

--- a/modules/sor/lib/pathGraph/pathGraph-proper-bfs.ts
+++ b/modules/sor/lib/pathGraph/pathGraph-proper-bfs.ts
@@ -1,0 +1,537 @@
+import { Address, SwapKind, Token, TokenAmount } from '@balancer/sdk';
+import { PathGraphEdgeData, PathGraphTraversalConfig } from './pathGraphTypes';
+import { BasePool } from '../poolsV2/basePool';
+import { PathLocal } from '../path';
+
+const DEFAULT_MAX_PATHS_PER_TOKEN_PAIR = 10;
+
+export class PathGraph {
+    private nodes: Map<string, { isPhantomBpt: boolean }>;
+    private edges: Map<string, Map<string, PathGraphEdgeData[]>>;
+    private poolAddressMap: Map<string, BasePool>;
+    private maxPathsPerTokenPair = DEFAULT_MAX_PATHS_PER_TOKEN_PAIR;
+
+    constructor() {
+        this.nodes = new Map();
+        this.edges = new Map();
+        this.poolAddressMap = new Map();
+    }
+
+    // We build a directed graph for all pools.
+    // Nodes are tokens and edges are triads: [pool.id, tokenIn, tokenOut].
+    // The current criterion for including a pool path into this graph is the following:
+    // (a) We include every path that includes a phantom BPT.
+    // (b) For any token pair x -> y, we include only the most liquid ${maxPathsPerTokenPair}
+    // pool pairs (default 2).
+    public buildGraph({
+        pools,
+        maxPathsPerTokenPair = DEFAULT_MAX_PATHS_PER_TOKEN_PAIR,
+        enableAddRemoveLiquidityPaths,
+    }: {
+        pools: BasePool[];
+        maxPathsPerTokenPair?: number;
+        enableAddRemoveLiquidityPaths: boolean;
+    }) {
+        this.poolAddressMap = new Map();
+        this.nodes = new Map();
+        this.edges = new Map();
+        this.maxPathsPerTokenPair = maxPathsPerTokenPair;
+
+        this.buildPoolAddressMap(pools);
+
+        this.addAllTokensAsGraphNodes({ pools, enableAddRemoveLiquidityPaths });
+
+        this.addTokenPairsAsGraphEdges({ pools, maxPathsPerTokenPair, enableAddRemoveLiquidityPaths });
+    }
+
+    // Since the path combinations here can get quite large, we use configurable parameters
+    // to enforce upper limits across several dimensions, defined in the pathConfig.
+    // (a) maxDepth - the max depth of the traversal (length of token path), defaults to 7.
+    // (b) maxNonBoostedPathDepth - the max depth for any path that does not contain a phantom bpt.
+    // (c) maxNonBoostedHopTokensInBoostedPath - The max number of non boosted hop tokens
+    // allowed in a boosted path.
+    // (d) approxPathsToReturn - search for up to this many paths. Since all paths for a single traversal
+    // are added, its possible that the amount returned is larger than this number.
+    // (e) poolIdsToInclude - Only include paths with these poolIds (optional)
+
+    // Additionally, we impose the following requirements for a path to be considered valid
+    // (a) It does not visit the same token twice
+    // (b) It does not use the same pool twice
+    public getCandidatePaths({
+        tokenIn,
+        tokenOut,
+        swapAmount,
+        swapKind,
+        graphTraversalConfig,
+    }: {
+        tokenIn: Token;
+        tokenOut: Token;
+        swapAmount: TokenAmount;
+        swapKind: SwapKind;
+        graphTraversalConfig?: Partial<PathGraphTraversalConfig>;
+    }): PathLocal[] {
+        const isHyperEvm = tokenIn.chainId === 999;
+
+        // apply defaults, allowing caller override whatever they'd like
+        const config: PathGraphTraversalConfig = {
+            maxDepth: 6,
+            maxNonBoostedPathDepth: 3,
+            maxNonBoostedHopTokensInBoostedPath: 2,
+            maxBuffersInPath: isHyperEvm ? 2 : 5, // limited only on HyperEvm due to gas cost limits on small blocks - virtually unlimited otherwise
+            approxPathsToReturn: 20, // Default to 20 - likely won't be reached, but acts as a bound to the computation if needed
+            maxRanksPerSegment: 2, // Default 2 for diversity
+            minSwapAmountRatio: 0.5, // Default to 50% so we're sure selected paths support splitPath logic
+            ...graphTraversalConfig,
+        };
+
+        // Calculate minimum limit threshold based on swap amount and ratio
+        const minLimitThreshold = (swapAmount.amount * BigInt(Math.floor(config.minSwapAmountRatio * 100))) / 100n;
+
+        const tokenPaths = this.findAllValidTokenPaths({
+            token: tokenIn.wrapped,
+            tokenIn: tokenIn.wrapped,
+            tokenOut: tokenOut.wrapped,
+            config,
+            tokenPath: [tokenIn.wrapped],
+        }).sort((a, b) => (a.length < b.length ? -1 : 1));
+
+        const paths: PathGraphEdgeData[][] = [];
+        const selectedPathIds: string[] = [];
+
+        // Use the new greedy best-first approach for each token path
+        for (const tokenPath of tokenPaths) {
+            const expandedPaths = this.expandTokenPathWithBestRanks({
+                tokenPath,
+                swapKind,
+                minLimitThreshold,
+                maxRanksPerSegment: config.maxRanksPerSegment,
+                approxPathsToReturn: config.approxPathsToReturn,
+            });
+
+            for (const path of expandedPaths) {
+                if (this.isValidPath({ path, seenPoolAddresses: [], selectedPathIds, config })) {
+                    selectedPathIds.push(this.getIdForPath(path));
+                    paths.push(path);
+                }
+            }
+        }
+
+        return this.sortAndFilterPaths(paths).map((path) => {
+            const pathTokens: Token[] = [...path.map((segment) => segment.tokenOut)];
+            pathTokens.unshift(tokenIn);
+            pathTokens[pathTokens.length - 1] = tokenOut;
+
+            return new PathLocal(
+                pathTokens,
+                path.map((segment) => segment.pool),
+                path.map((segment) => segment.isBuffer),
+            );
+        });
+    }
+
+    private sortAndFilterPaths(paths: PathGraphEdgeData[][]): PathGraphEdgeData[][] {
+        const pathsWithLimits = paths
+            .map((path) => {
+                try {
+                    const limit = this.getLimitAmountSwapForPath(path, SwapKind.GivenIn);
+                    return { path, limit };
+                } catch (_e) {
+                    console.log('Error getting limit for path', path.map((p) => p.pool.id).join(' -> '));
+                    return undefined;
+                }
+            })
+            .filter((path): path is { path: PathGraphEdgeData[]; limit: bigint } => !!path)
+            .sort((a, b) => (a.limit < b.limit ? 1 : -1));
+
+        const filtered: PathGraphEdgeData[][] = [];
+
+        // Remove any paths with duplicate pools. since the paths are now sorted by limit,
+        // selecting the first path will always be the optimal.
+        for (const { path } of pathsWithLimits) {
+            let seenPools: string[] = [];
+            let isValid = true;
+
+            for (const segment of path) {
+                if (seenPools.includes(segment.pool.id)) {
+                    isValid = false;
+                    break;
+                }
+            }
+
+            if (isValid) {
+                filtered.push(path);
+                seenPools = [...seenPools, ...path.map((segment) => segment.pool.id)];
+            }
+        }
+
+        return filtered;
+    }
+
+    private buildPoolAddressMap(pools: BasePool[]) {
+        for (const pool of pools) {
+            this.poolAddressMap.set(pool.address.toLowerCase(), pool);
+        }
+    }
+
+    private addAllTokensAsGraphNodes({
+        pools,
+        enableAddRemoveLiquidityPaths,
+    }: {
+        pools: BasePool[];
+        enableAddRemoveLiquidityPaths: boolean;
+    }) {
+        for (const pool of pools) {
+            const tokens = [...pool.tokens.map((t) => t.token)];
+            if (enableAddRemoveLiquidityPaths && pool.poolType !== 'Buffer') {
+                tokens.push(new Token(pool.tokens[0].token.chainId, pool.address.toLowerCase() as Address, 18)); // Add BPT as token nodes
+            }
+            for (const token of tokens) {
+                if (!this.nodes.has(token.wrapped)) {
+                    this.addNode(token);
+                }
+            }
+        }
+    }
+
+    private addTokenPairsAsGraphEdges({
+        pools,
+        maxPathsPerTokenPair,
+        enableAddRemoveLiquidityPaths,
+    }: {
+        pools: BasePool[];
+        maxPathsPerTokenPair: number;
+        enableAddRemoveLiquidityPaths: boolean;
+    }) {
+        for (const pool of pools) {
+            const tokens = [...pool.tokens.map((t) => t.token)];
+            if (enableAddRemoveLiquidityPaths && pool.poolType !== 'Buffer') {
+                tokens.push(new Token(pool.tokens[0].token.chainId, pool.address.toLowerCase() as Address, 18)); // Also consider BPT token pairs
+            }
+            for (const tokenIn of tokens) {
+                for (const tokenOut of tokens) {
+                    if (tokenIn === tokenOut) continue;
+                    this.addEdge({
+                        edgeProps: {
+                            pool,
+                            tokenIn,
+                            tokenOut,
+                            normalizedLiquidity: pool.getNormalizedLiquidity(tokenIn, tokenOut),
+                            isBuffer: pool.poolType === 'Buffer',
+                        },
+                        maxPathsPerTokenPair,
+                    });
+                }
+            }
+        }
+    }
+
+    private addNode(token: Token): void {
+        this.nodes.set(token.wrapped, {
+            isPhantomBpt: !!this.poolAddressMap.get(token.wrapped),
+        });
+
+        if (!this.edges.has(token.wrapped)) {
+            this.edges.set(token.wrapped, new Map());
+        }
+    }
+
+    /**
+     * Adds a directed edge from a source vertex to a destination
+     */
+    private addEdge({
+        edgeProps,
+        maxPathsPerTokenPair,
+    }: {
+        edgeProps: PathGraphEdgeData;
+        maxPathsPerTokenPair: number;
+    }): void {
+        const tokenInVertex = this.nodes.get(edgeProps.tokenIn.wrapped);
+        const tokenOutVertex = this.nodes.get(edgeProps.tokenOut.wrapped);
+        const tokenInNode = this.edges.get(edgeProps.tokenIn.wrapped);
+
+        if (!tokenInVertex || !tokenOutVertex || !tokenInNode) {
+            throw new Error('Attempting to add invalid edge');
+        }
+
+        const hasPhantomBpt = tokenInVertex.isPhantomBpt || tokenOutVertex.isPhantomBpt;
+        const existingEdges = tokenInNode.get(edgeProps.tokenOut.wrapped) || [];
+
+        //TODO: ideally we don't call sort every time, this isn't performant
+        const sorted = [...existingEdges, edgeProps].sort((a, b) =>
+            a.normalizedLiquidity > b.normalizedLiquidity ? -1 : 1,
+        );
+
+        // TODO: double check if the hasPhantomBpt issue is not affecting v3 liquidity more frequently (considering all
+        // pools have their BPT artificially added so we consider them for add/remove liquidity steps)
+        tokenInNode.set(
+            edgeProps.tokenOut.wrapped,
+            sorted.length > maxPathsPerTokenPair && !hasPhantomBpt ? sorted.slice(0, maxPathsPerTokenPair) : sorted,
+        );
+    }
+
+    private findAllValidTokenPaths({
+        token,
+        tokenIn,
+        tokenOut,
+        tokenPath,
+        config,
+    }: {
+        token: string;
+        tokenIn: string;
+        tokenOut: string;
+        tokenPath: string[];
+        config: PathGraphTraversalConfig;
+    }): string[][] {
+        const results: string[][] = [];
+        const queue: { node: string; path: string[] }[] = [{ node: token, path: tokenPath }];
+
+        while (queue.length > 0) {
+            const { node, path } = queue.shift()!;
+
+            const neighbors = this.edges.get(node);
+            if (!neighbors) continue;
+
+            for (const [neighbor] of neighbors) {
+                // small hot-path optimization: check length bounds before cloning array
+                if (path.length + 1 > config.maxDepth) continue;
+
+                if (path.includes(neighbor)) continue; // no cycles
+
+                const newPath = [...path, neighbor];
+                if (!this.isValidTokenPath({ tokenPath: newPath, tokenIn, tokenOut, config })) continue;
+
+                if (neighbor === tokenOut) {
+                    results.push(newPath);
+                } else {
+                    // push longer path into queue
+                    queue.push({ node: neighbor, path: newPath });
+                }
+            }
+        }
+
+        return results;
+    }
+
+    private isValidTokenPath({
+        tokenPath,
+        config,
+        tokenIn,
+        tokenOut,
+    }: {
+        tokenPath: string[];
+        config: PathGraphTraversalConfig;
+        tokenIn: string;
+        tokenOut: string;
+    }) {
+        const isCompletePath = tokenPath[tokenPath.length - 1] === tokenOut;
+        const hopTokens = tokenPath.filter((token) => token !== tokenIn && token !== tokenOut);
+        const numStandardHopTokens = hopTokens.filter((token) => !this.poolAddressMap.has(token)).length;
+        const isBoostedPath = tokenPath.filter((token) => this.poolAddressMap.has(token)).length > 0;
+
+        if (tokenPath.length > config.maxDepth) {
+            return false;
+        }
+
+        if (isBoostedPath && numStandardHopTokens > config.maxNonBoostedHopTokensInBoostedPath) {
+            return false;
+        }
+
+        // if the path length is greater than maxNonBoostedPathDepth, then this path
+        // will only be valid if its a boosted path, so it must honor maxNonBoostedHopTokensInBoostedPath
+        if (
+            tokenPath.length > config.maxNonBoostedPathDepth &&
+            numStandardHopTokens > config.maxNonBoostedHopTokensInBoostedPath
+        ) {
+            return false;
+        }
+
+        if (isCompletePath && !isBoostedPath && tokenPath.length > config.maxNonBoostedPathDepth) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private isValidPath({
+        path,
+        seenPoolAddresses,
+        selectedPathIds,
+        config,
+    }: {
+        path: PathGraphEdgeData[];
+        seenPoolAddresses: string[];
+        selectedPathIds: string[];
+        config: PathGraphTraversalConfig;
+    }) {
+        const poolIdsInPath = path.map((segment) => segment.pool.id);
+        const uniquePools = [...new Set(poolIdsInPath)];
+
+        if (config.poolIdsToInclude) {
+            for (const poolId of poolIdsInPath) {
+                if (!config.poolIdsToInclude.map((id) => id.toLowerCase()).includes(poolId.toLowerCase())) {
+                    //path includes a pool that is not allowed for this traversal
+                    return false;
+                }
+            }
+        }
+
+        //dont include any path that hops through the same pool twice
+        if (uniquePools.length !== poolIdsInPath.length) {
+            return false;
+        }
+
+        for (const segment of path) {
+            if (seenPoolAddresses.includes(segment.pool.address)) {
+                //this path contains a pool that has already been used
+                return false;
+            }
+        }
+
+        //this is a duplicate path
+        if (selectedPathIds.includes(this.getIdForPath(path))) {
+            return false;
+        }
+
+        if (path.filter((segment) => segment.isBuffer).length > config.maxBuffersInPath) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private getIdForPath(path: PathGraphEdgeData[]): string {
+        let id = '';
+
+        for (const segment of path) {
+            if (id.length > 0) {
+                id += '_';
+            }
+
+            id += `${segment.pool.id}-${segment.tokenIn}-${segment.tokenOut}`;
+        }
+
+        return id;
+    }
+
+    private getLimitAmountSwapForPath(path: PathGraphEdgeData[], swapKind: SwapKind): bigint {
+        let limit = path[path.length - 1].pool.getLimitAmountSwap(
+            path[path.length - 1].tokenIn,
+            path[path.length - 1].tokenOut,
+            swapKind,
+        );
+
+        for (let i = path.length - 2; i >= 0; i--) {
+            const poolLimitExactIn = path[i].pool.getLimitAmountSwap(
+                path[i].tokenIn,
+                path[i].tokenOut,
+                SwapKind.GivenIn,
+            );
+            const poolLimitExactOut = path[i].pool.getLimitAmountSwap(
+                path[i].tokenIn,
+                path[i].tokenOut,
+                SwapKind.GivenOut,
+            );
+
+            if (poolLimitExactOut <= limit) {
+                limit = poolLimitExactIn;
+            } else {
+                const pulledLimit = path[i].pool.swapGivenOut(
+                    path[i].tokenIn,
+                    path[i].tokenOut,
+                    TokenAmount.fromRawAmount(path[i].tokenOut, limit),
+                ).amount;
+
+                limit = pulledLimit > poolLimitExactIn ? poolLimitExactIn : pulledLimit;
+            }
+        }
+
+        return limit;
+    }
+
+    /**
+     * Expands a token path using a greedy best-first approach with early limit checking.
+     * Instead of exploring all rank combinations, this prioritizes highest liquidity options
+     * and stops when paths meet the minimum limit threshold.
+     */
+    private expandTokenPathWithBestRanks({
+        tokenPath,
+        swapKind,
+        minLimitThreshold,
+        maxRanksPerSegment,
+        approxPathsToReturn,
+    }: {
+        tokenPath: string[];
+        swapKind: SwapKind;
+        minLimitThreshold: bigint;
+        maxRanksPerSegment: number;
+        approxPathsToReturn: number;
+    }): PathGraphEdgeData[][] {
+        const results: PathGraphEdgeData[][] = [];
+        const seen = new Set<string>();
+
+        // Start with all-segment rank 0
+        const queue: number[][] = [new Array(tokenPath.length - 1).fill(0)];
+
+        while (queue.length > 0 && results.length < approxPathsToReturn) {
+            const ranks = queue.shift()!;
+            const key = ranks.join(',');
+            if (seen.has(key)) continue;
+            seen.add(key);
+
+            let path: PathGraphEdgeData[];
+            try {
+                path = this.expandTokenPathWithRanks({ tokenPath, ranks });
+            } catch {
+                continue; // skip invalid rank combination
+            }
+
+            try {
+                const limit = this.getLimitAmountSwapForPath(path, swapKind);
+                if (limit >= minLimitThreshold) {
+                    results.push(path);
+
+                    // enqueue "neighboring" rank choices — but bounded by maxRanksPerSegment
+                    for (let i = 0; i < ranks.length; i++) {
+                        if (ranks[i] + 1 < maxRanksPerSegment && ranks[i] + 1 < this.maxPathsPerTokenPair) {
+                            const newRanks = [...ranks];
+                            newRanks[i]++;
+                            queue.push(newRanks);
+                        }
+                    }
+                }
+            } catch {
+                // If limit computation fails, just skip
+            }
+        }
+
+        return results;
+    }
+
+    /**
+     * Expands a token path using different liquidity ranks for each segment.
+     * This allows exploring all combinations of pool liquidity ranks for different token pairs in a path.
+     * @param tokenPath - Array of token addresses representing the path
+     * @param ranks - Array of liquidity ranks to use for each segment (must match path length - 1)
+     */
+    private expandTokenPathWithRanks({ tokenPath, ranks }: { tokenPath: string[]; ranks: number[] }) {
+        const segments: PathGraphEdgeData[] = [];
+
+        for (let i = 0; i < tokenPath.length - 1; i++) {
+            const edge = this.edges.get(tokenPath[i])?.get(tokenPath[i + 1]);
+
+            if (!edge || edge.length === 0) {
+                throw new Error(`Missing edge for pair ${tokenPath[i]} -> ${tokenPath[i + 1]}`);
+            }
+
+            const rank = ranks[i];
+
+            if (!edge[rank]) {
+                throw new Error(`Missing rank ${rank} on edge for pair ${tokenPath[i]} -> ${tokenPath[i + 1]}`);
+            }
+
+            segments.push(edge[rank]);
+        }
+
+        return segments;
+    }
+}

--- a/modules/sor/lib/pathGraph/pathGraph-proper-bfs.ts
+++ b/modules/sor/lib/pathGraph/pathGraph-proper-bfs.ts
@@ -4,7 +4,7 @@ import { PathGraphEdgeData, PathGraphTraversalConfig } from './pathGraphTypes';
 import { BasePool } from '../poolsV2/basePool';
 import { PathLocal } from '../path';
 
-const DEFAULT_MAX_PATHS_PER_TOKEN_PAIR = 2;
+const DEFAULT_MAX_PATHS_PER_TOKEN_PAIR = 4;
 
 export class PathGraphBfs {
     private nodes: Map<string, { isPhantomBpt: boolean }>;
@@ -77,22 +77,19 @@ export class PathGraphBfs {
         swapAmount,
         swapKind,
         graphTraversalConfig,
-        minLimitThresholdUSD,
     }: {
         tokenIn: Token;
         tokenOut: Token;
         swapAmount: TokenAmount;
         swapKind: SwapKind;
         graphTraversalConfig?: Partial<PathGraphTraversalConfig>;
-        minLimitThresholdUSD?: number;
     }): PathLocal[] {
         const isHyperEvm = tokenIn.chainId === 999;
 
         // apply defaults, allowing caller override whatever they'd like
         const config: PathGraphTraversalConfig = {
-            maxDepth: 6,
-            maxNonBoostedPathDepth: 3,
-            maxNonBoostedHopTokensInBoostedPath: 2,
+            maxDepth: 4,
+            maxTokenPaths: 50,
             maxBuffersInPath: isHyperEvm ? 2 : 5, // limited only on HyperEvm due to gas cost limits on small blocks - virtually unlimited otherwise
             approxPathsToReturn: 20, // Default to 20 - likely won't be reached, but acts as a bound to the computation if needed
             maxRanksPerSegment: 2, // Default 2 for diversity
@@ -104,12 +101,11 @@ export class PathGraphBfs {
         const minLimitThreshold = (swapAmount.amount * BigInt(Math.floor(config.minSwapAmountRatio * 100))) / 100n;
 
         const tokenPaths = this.findAllValidTokenPaths({
-            token: tokenIn.wrapped,
             tokenIn: tokenIn.wrapped,
             tokenOut: tokenOut.wrapped,
             config,
-            tokenPath: [tokenIn.wrapped],
-        }).sort((a, b) => (a.length < b.length ? -1 : 1));
+        });
+        console.log('tokenPaths found -> ', tokenPaths.length);
 
         const paths: PathGraphEdgeData[][] = [];
         const selectedPathIds: string[] = [];
@@ -288,22 +284,18 @@ export class PathGraphBfs {
     }
 
     private findAllValidTokenPaths({
-        token,
         tokenIn,
         tokenOut,
-        tokenPath,
         config,
     }: {
-        token: string;
         tokenIn: string;
         tokenOut: string;
-        tokenPath: string[];
         config: PathGraphTraversalConfig;
     }): string[][] {
         const results: string[][] = [];
-        const queue: { node: string; path: string[] }[] = [{ node: token, path: tokenPath }];
+        const queue: { node: string; path: string[] }[] = [{ node: tokenIn, path: [tokenIn] }];
 
-        while (queue.length > 0) {
+        while (queue.length > 0 && results.length < config.maxTokenPaths) {
             const { node, path } = queue.shift()!;
 
             const neighbors = this.edges.get(node);
@@ -313,10 +305,10 @@ export class PathGraphBfs {
                 // small hot-path optimization: check length bounds before cloning array
                 if (path.length + 1 > config.maxDepth) continue;
 
-                if (path.includes(neighbor)) continue; // no cycles
+                // no cycles
+                if (path.includes(neighbor)) continue;
 
                 const newPath = [...path, neighbor];
-                if (!this.isValidTokenPath({ tokenPath: newPath, tokenIn, tokenOut, config })) continue;
 
                 if (neighbor === tokenOut) {
                     results.push(newPath);
@@ -328,46 +320,6 @@ export class PathGraphBfs {
         }
 
         return results;
-    }
-
-    private isValidTokenPath({
-        tokenPath,
-        config,
-        tokenIn,
-        tokenOut,
-    }: {
-        tokenPath: string[];
-        config: PathGraphTraversalConfig;
-        tokenIn: string;
-        tokenOut: string;
-    }) {
-        const isCompletePath = tokenPath[tokenPath.length - 1] === tokenOut;
-        const hopTokens = tokenPath.filter((token) => token !== tokenIn && token !== tokenOut);
-        const numStandardHopTokens = hopTokens.filter((token) => !this.poolAddressMap.has(token)).length;
-        const isBoostedPath = tokenPath.filter((token) => this.poolAddressMap.has(token)).length > 0;
-
-        if (tokenPath.length > config.maxDepth) {
-            return false;
-        }
-
-        if (isBoostedPath && numStandardHopTokens > config.maxNonBoostedHopTokensInBoostedPath) {
-            return false;
-        }
-
-        // if the path length is greater than maxNonBoostedPathDepth, then this path
-        // will only be valid if its a boosted path, so it must honor maxNonBoostedHopTokensInBoostedPath
-        if (
-            tokenPath.length > config.maxNonBoostedPathDepth &&
-            numStandardHopTokens > config.maxNonBoostedHopTokensInBoostedPath
-        ) {
-            return false;
-        }
-
-        if (isCompletePath && !isBoostedPath && tokenPath.length > config.maxNonBoostedPathDepth) {
-            return false;
-        }
-
-        return true;
     }
 
     private isValidPath({
@@ -485,18 +437,24 @@ export class PathGraphBfs {
         const results: PathGraphEdgeData[][] = [];
         const seen = new Set<string>();
 
+        const segmentCount = tokenPath.length - 1;
+        if (segmentCount <= 0) return [];
+        // Gather candidate edges per segment (already sorted by normalizedLiquidity desc).
+        const perSegmentEdges: PathGraphEdgeData[][] = new Array(segmentCount);
+        for (let i = 0; i < segmentCount; i++) {
+            const edges = this.edges.get(tokenPath[i])?.get(tokenPath[i + 1]);
+            if (!edges) return []; // path cannot be built
+            perSegmentEdges[i] = edges;
+        }
+
         // Start with all-segment rank 0
         const queue: number[][] = [new Array(tokenPath.length - 1).fill(0)];
 
         while (queue.length > 0 && results.length < approxPathsToReturn) {
             const ranks = queue.shift()!;
-            const key = ranks.join(',');
-            if (seen.has(key)) continue;
-            seen.add(key);
 
-            let path: PathGraphEdgeData[];
             try {
-                path = this.expandTokenPathWithRanks({ tokenPath, ranks });
+                const path = this.expandTokenPathWithRanks({ perSegmentEdges, ranks });
                 const limit = this.getLimitAmountSwapForPath(path, swapKind);
                 if (limit >= minLimitThreshold) {
                     results.push(path);
@@ -524,23 +482,22 @@ export class PathGraphBfs {
      * @param tokenPath - Array of token addresses representing the path
      * @param ranks - Array of liquidity ranks to use for each segment (must match path length - 1)
      */
-    private expandTokenPathWithRanks({ tokenPath, ranks }: { tokenPath: string[]; ranks: number[] }) {
+    private expandTokenPathWithRanks({
+        perSegmentEdges,
+        ranks,
+    }: {
+        perSegmentEdges: PathGraphEdgeData[][];
+        ranks: number[];
+    }) {
         const segments: PathGraphEdgeData[] = [];
 
-        for (let i = 0; i < tokenPath.length - 1; i++) {
-            const edge = this.edges.get(tokenPath[i])?.get(tokenPath[i + 1]);
-
-            if (!edge || edge.length === 0) {
-                throw new Error(`Missing edge for pair ${tokenPath[i]} -> ${tokenPath[i + 1]}`);
-            }
-
+        for (let i = 0; i < perSegmentEdges.length; i++) {
+            const edgeChoices = perSegmentEdges[i];
             const rank = ranks[i];
-
-            if (!edge[rank]) {
-                throw new Error(`Missing rank ${rank} on edge for pair ${tokenPath[i]} -> ${tokenPath[i + 1]}`);
+            if (!edgeChoices[rank]) {
+                throw new Error('Missing rank on edge for segment');
             }
-
-            segments.push(edge[rank]);
+            segments.push(edgeChoices[rank]);
         }
 
         return segments;

--- a/modules/sor/lib/pathGraph/pathGraph.test.ts
+++ b/modules/sor/lib/pathGraph/pathGraph.test.ts
@@ -1,0 +1,392 @@
+import { PathGraph } from './pathGraph';
+import { BasePool } from '../poolsV2/basePool';
+import { Token, TokenAmount, SwapKind } from '@balancer/sdk';
+import { describe, test, expect, mock, spyOn, beforeEach } from 'bun:test';
+
+const baseConfig = {
+    maxDepth: 6,
+    maxNonBoostedPathDepth: 3,
+    maxNonBoostedHopTokensInBoostedPath: 2,
+    maxBuffersInPath: 5,
+    approxPathsToReturn: 20,
+    maxRanksPerSegment: 2,
+    minSwapAmountRatio: 0.5,
+};
+
+function createMockPool(id: string, tokens: Token[], opts: Partial<BasePool> = {}): BasePool {
+    return {
+        id,
+        address: id,
+        poolType: opts.poolType ?? 'Weighted',
+        tokens: tokens.map((t) => ({ token: t })),
+        getNormalizedLiquidity: opts.getNormalizedLiquidity ?? (() => 100n),
+        getLimitAmountSwap: opts.getLimitAmountSwap ?? (() => 1_000_000n),
+        swapGivenOut: opts.swapGivenOut ?? ((_in: Token, _out: Token, amt: TokenAmount) => amt),
+        ...opts,
+    } as unknown as BasePool;
+}
+
+describe('PathGraph search algorithms', () => {
+    const tokenA = new Token(1, '0xa', 18);
+    const tokenB = new Token(1, '0xb', 18);
+    const tokenC = new Token(1, '0xc', 18);
+    const tokenD = new Token(1, '0xd', 18);
+    const tokenE = new Token(1, '0xe', 18); // extra token for extended tests
+
+    let pools: BasePool[];
+    let graph: PathGraph;
+
+    beforeEach(() => {
+        pools = [
+            createMockPool('p1', [tokenA, tokenB]),
+            createMockPool('p2', [tokenB, tokenC]),
+            createMockPool('p3', [tokenC, tokenD]),
+            createMockPool('p4', [tokenA, tokenD], { poolType: 'Buffer' }),
+        ];
+        graph = new PathGraph();
+        graph.buildGraph({ pools, enableAddRemoveLiquidityPaths: false });
+    });
+
+    test('finds direct path', () => {
+        const paths = graph['findAllValidTokenPaths']({
+            token: tokenA.wrapped,
+            tokenIn: tokenA.wrapped,
+            tokenOut: tokenB.wrapped,
+            tokenPath: [tokenA.wrapped],
+            config: { ...baseConfig },
+        });
+
+        expect(paths).toContainEqual([tokenA.wrapped, tokenB.wrapped]);
+    });
+
+    test('avoids revisiting tokens (no cycles)', () => {
+        // path A -> B -> A -> B should not appear
+        const paths = graph['findAllValidTokenPaths']({
+            token: tokenA.wrapped,
+            tokenIn: tokenA.wrapped,
+            tokenOut: tokenC.wrapped,
+            tokenPath: [tokenA.wrapped],
+            config: { ...baseConfig },
+        });
+
+        for (const path of paths) {
+            const visited = new Set(path);
+            expect(visited.size).toBe(path.length); // ensures no duplicate token
+        }
+    });
+
+    test('respects maxDepth limit', () => {
+        const paths = graph['findAllValidTokenPaths']({
+            token: tokenA.wrapped,
+            tokenIn: tokenA.wrapped,
+            tokenOut: tokenD.wrapped,
+            tokenPath: [tokenA.wrapped],
+            config: { ...baseConfig, maxDepth: 2, maxNonBoostedPathDepth: 2, maxNonBoostedHopTokensInBoostedPath: 1 },
+        });
+
+        // Only A -> D (buffer pool) should be valid, not A -> B -> C -> D
+        expect(paths).toContainEqual([tokenA.wrapped, tokenD.wrapped]);
+        expect(paths).not.toContainEqual([tokenA.wrapped, tokenB.wrapped, tokenC.wrapped, tokenD.wrapped]);
+    });
+
+    test('expandTokenPathWithBestRanks keeps at least rank-0 path', () => {
+        const path = [tokenA.wrapped, tokenB.wrapped, tokenC.wrapped];
+        const result = graph['expandTokenPathWithBestRanks']({
+            tokenPath: path,
+            swapKind: SwapKind.GivenIn,
+            minLimitThreshold: 1n,
+            maxRanksPerSegment: 2,
+            approxPathsToReturn: 5,
+        });
+
+        expect(result.length).toBeGreaterThan(0);
+        // path[0] should be p1 rank-0, path[1] should be p2 rank-0
+        result.forEach((segments) => {
+            expect(segments.every((s) => !!s.pool)).toBe(true);
+        });
+    });
+
+    //
+    // Added tests start here
+    //
+
+    test('findAllValidTokenPaths traversal order is depth-first (naming mismatch: traverseBfs is DFS)', () => {
+        // Build a simple diamond: A->B->D and A->C->D, ensure neighbor order is B then C
+        const g = new PathGraph();
+        const localPools = [
+            createMockPool('pAB', [tokenA, tokenB]),
+            createMockPool('pAC', [tokenA, tokenC]),
+            createMockPool('pBD', [tokenB, tokenD]),
+            createMockPool('pCD', [tokenC, tokenD]),
+        ];
+        g.buildGraph({ pools: localPools, enableAddRemoveLiquidityPaths: false });
+
+        const paths = g['findAllValidTokenPaths']({
+            token: tokenA.wrapped,
+            tokenIn: tokenA.wrapped,
+            tokenOut: tokenD.wrapped,
+            tokenPath: [tokenA.wrapped],
+            config: { ...baseConfig },
+        });
+
+        // Expect DFS-like order: first via B, then via C
+        expect(paths[0]).toEqual([tokenA.wrapped, tokenB.wrapped, tokenD.wrapped]);
+        expect(paths[1]).toEqual([tokenA.wrapped, tokenC.wrapped, tokenD.wrapped]);
+    });
+
+    test('isValidPath rejects paths that reuse the same pool within a single path', () => {
+        // Single tri-token pool can service both hops -> would reuse same pool
+        const g = new PathGraph();
+        const tri = createMockPool('pTri', [tokenA, tokenB, tokenC]);
+        g.buildGraph({ pools: [tri], enableAddRemoveLiquidityPaths: false });
+
+        const tokenPath = [tokenA.wrapped, tokenB.wrapped, tokenC.wrapped];
+
+        // Expand to segments (likely both segments from pTri)
+        const expanded = g['expandTokenPathWithBestRanks']({
+            tokenPath,
+            swapKind: SwapKind.GivenIn,
+            minLimitThreshold: 1n,
+            maxRanksPerSegment: 2,
+            approxPathsToReturn: 5,
+        });
+
+        // Ensure at least one candidate uses the same pool twice (pTri)
+        const candidateThatReusesPool = expanded.find(
+            (segs) => new Set(segs.map((s) => s.pool.id)).size !== segs.length,
+        );
+        expect(candidateThatReusesPool).toBeDefined();
+
+        // Validate isValidPath returns false for that candidate
+        const isValid = g['isValidPath']({
+            path: candidateThatReusesPool!,
+            seenPoolAddresses: [],
+            selectedPathIds: [],
+            config: { ...baseConfig },
+        });
+        expect(isValid).toBe(false);
+    });
+
+    test('getCandidatePaths respects poolIdsToInclude whitelist (filters mixed paths)', () => {
+        // A->B->C exists via p1 then p2, but we only allow p2 -> should filter out
+        const g = new PathGraph();
+        const p1 = createMockPool('p1', [tokenA, tokenB]);
+        const p2 = createMockPool('p2', [tokenB, tokenC]);
+        g.buildGraph({ pools: [p1, p2], enableAddRemoveLiquidityPaths: false });
+
+        const paths = g.getCandidatePaths({
+            tokenIn: tokenA,
+            tokenOut: tokenC,
+            swapAmount: TokenAmount.fromRawAmount(tokenA, 1_000n),
+            swapKind: SwapKind.GivenIn,
+            graphTraversalConfig: {
+                ...baseConfig,
+                poolIdsToInclude: ['p2'], // p1 not allowed
+            },
+        });
+
+        expect(paths.length).toBe(0);
+    });
+
+    test('maxBuffersInPath is enforced', () => {
+        // Two buffer pools in sequence, but limit maxBuffersInPath=1 => filtered out
+        const g = new PathGraph();
+        const buf1 = createMockPool('buf1', [tokenA, tokenB], { poolType: 'Buffer' });
+        const buf2 = createMockPool('buf2', [tokenB, tokenC], { poolType: 'Buffer' });
+        g.buildGraph({ pools: [buf1, buf2], enableAddRemoveLiquidityPaths: false });
+
+        const paths = g.getCandidatePaths({
+            tokenIn: tokenA,
+            tokenOut: tokenC,
+            swapAmount: TokenAmount.fromRawAmount(tokenA, 1_000n),
+            swapKind: SwapKind.GivenIn,
+            graphTraversalConfig: {
+                ...baseConfig,
+                maxBuffersInPath: 1, // path has 2 buffers -> invalid
+            },
+        });
+
+        expect(paths.length).toBe(0);
+    });
+
+    test('respects maxPathsPerTokenPair (keeps only top-K ranked edges for a pair)', () => {
+        // Three pools for the same pair A<->B with different liquidity; cap at K=2
+        const g = new PathGraph();
+
+        const pAB1 = createMockPool('pAB1', [tokenA, tokenB], { getNormalizedLiquidity: () => 300n });
+        const pAB2 = createMockPool('pAB2', [tokenA, tokenB], { getNormalizedLiquidity: () => 200n });
+        const pAB3 = createMockPool('pAB3', [tokenA, tokenB], { getNormalizedLiquidity: () => 100n });
+
+        g.buildGraph({
+            pools: [pAB1, pAB2, pAB3],
+            enableAddRemoveLiquidityPaths: false,
+            maxPathsPerTokenPair: 2,
+        });
+
+        const result = g['expandTokenPathWithBestRanks']({
+            tokenPath: [tokenA.wrapped, tokenB.wrapped],
+            swapKind: SwapKind.GivenIn,
+            minLimitThreshold: 1n,
+            maxRanksPerSegment: 5, // try to explore more
+            approxPathsToReturn: 10,
+        });
+
+        const poolsUsed = new Set<string>(result.map((segments) => segments[0].pool.id));
+
+        expect(result.length).toBeLessThanOrEqual(2);
+        expect(poolsUsed.has('pAB1')).toBe(true);
+        expect(poolsUsed.has('pAB2')).toBe(true);
+        expect(poolsUsed.has('pAB3')).toBe(false); // trimmed by top-K
+    });
+
+    test('expandTokenPathWithBestRanks is resilient even when ranks exceed available edges', () => {
+        // Only one edge exists for A->B, but exploration limits are high
+        const g = new PathGraph();
+        const pAB = createMockPool('pAB', [tokenA, tokenB]);
+        g.buildGraph({ pools: [pAB], enableAddRemoveLiquidityPaths: false });
+
+        const result = g['expandTokenPathWithBestRanks']({
+            tokenPath: [tokenA.wrapped, tokenB.wrapped],
+            swapKind: SwapKind.GivenIn,
+            minLimitThreshold: 1n,
+            maxRanksPerSegment: 10, // > available edge ranks
+            approxPathsToReturn: 10,
+        });
+
+        expect(result.length).toBe(1);
+        expect(result[0][0].pool.id as string).toBe('pAB');
+    });
+
+    // Optional: illustrate the quantization issue in minSwapAmountRatio (tiny ratios < 0.01 become zero threshold)
+    test('minSwapAmountRatio quantization can yield zero threshold for tiny ratios', () => {
+        const g = new PathGraph();
+        const pAB = createMockPool('pAB', [tokenA, tokenB], {
+            getLimitAmountSwap: () => 5n,
+        });
+        g.buildGraph({ pools: [pAB], enableAddRemoveLiquidityPaths: false });
+
+        const tinyRatio = 0.009; // floor(0.9)/100 = 0 => zero threshold with current logic
+        const paths = g.getCandidatePaths({
+            tokenIn: tokenA,
+            tokenOut: tokenB,
+            swapAmount: TokenAmount.fromRawAmount(tokenA, 100n),
+            swapKind: SwapKind.GivenIn,
+            graphTraversalConfig: { ...baseConfig, minSwapAmountRatio: tinyRatio },
+        });
+
+        // Should return at least the direct path; this passes now,
+        // but demonstrates that the threshold is effectively zero for tiny ratios.
+        expect(paths.length).toBeGreaterThan(0);
+    });
+
+    test('reuses a pool across selected paths', () => {
+        const g = new PathGraph();
+        // pShared contains [B, C, D], so both B->D and C->D can use the same pool
+        const pAB = createMockPool('pAB', [tokenA, tokenB]);
+        const pAC = createMockPool('pAC', [tokenA, tokenC]);
+        const pShared = createMockPool('pShared', [tokenB, tokenC, tokenD]);
+
+        g.buildGraph({ pools: [pAB, pAC, pShared], enableAddRemoveLiquidityPaths: false });
+
+        const paths = g.getCandidatePaths({
+            tokenIn: tokenA,
+            tokenOut: tokenD,
+            swapAmount: TokenAmount.fromRawAmount(tokenA, 10_000n),
+            swapKind: SwapKind.GivenIn,
+            graphTraversalConfig: { ...baseConfig },
+        });
+
+        expect(paths.length).toBe(2);
+    });
+
+    describe('performance-safety invariants', () => {
+        const tokenA = new Token(1, '0xa', 18);
+        const tokenB = new Token(1, '0xb', 18);
+        const tokenC = new Token(1, '0xc', 18);
+
+        test('edges are trimmed to top-K and kept in descending normalizedLiquidity order', () => {
+            const g = new PathGraph();
+
+            const pAB4 = createMockPool('pAB4', [tokenA, tokenB], { getNormalizedLiquidity: () => 400n });
+            const pAB3 = createMockPool('pAB3', [tokenA, tokenB], { getNormalizedLiquidity: () => 300n });
+            const pAB2 = createMockPool('pAB2', [tokenA, tokenB], { getNormalizedLiquidity: () => 200n });
+            const pAB1 = createMockPool('pAB1', [tokenA, tokenB], { getNormalizedLiquidity: () => 100n });
+
+            g.buildGraph({
+                pools: [pAB1, pAB2, pAB3, pAB4],
+                enableAddRemoveLiquidityPaths: false,
+                maxPathsPerTokenPair: 3,
+            });
+
+            const edges = (g as any).edges.get(tokenA.wrapped).get(tokenB.wrapped);
+            const liqs = edges.map((e: any) => e.normalizedLiquidity);
+
+            expect(edges.length).toBe(3);
+            expect(liqs).toEqual([400n, 300n, 200n]); // strictly descending and top-3 kept
+        });
+
+        test('expandTokenPathWithBestRanks respects approxPathsToReturn cap', () => {
+            const g = new PathGraph();
+
+            // Create multiple ranks for both segments A->B and B->C
+            const abPools = Array.from({ length: 5 }, (_, i) =>
+                createMockPool(`pAB${i}`, [tokenA, tokenB], { getNormalizedLiquidity: () => BigInt(1000 - i) }),
+            );
+            const bcPools = Array.from({ length: 5 }, (_, i) =>
+                createMockPool(`pBC${i}`, [tokenB, tokenC], { getNormalizedLiquidity: () => BigInt(1000 - i) }),
+            );
+
+            g.buildGraph({
+                pools: [...abPools, ...bcPools],
+                enableAddRemoveLiquidityPaths: false,
+                maxPathsPerTokenPair: 5,
+            });
+
+            const result = (g as any).expandTokenPathWithBestRanks({
+                tokenPath: [tokenA.wrapped, tokenB.wrapped, tokenC.wrapped],
+                swapKind: SwapKind.GivenIn,
+                minLimitThreshold: 1n,
+                maxRanksPerSegment: 5,
+                approxPathsToReturn: 3,
+            });
+
+            expect(result.length).toBeLessThanOrEqual(3);
+            expect(result.length).toBeGreaterThan(0);
+        });
+
+        test('getCandidatePaths respects approxPathsToReturn when there is only a single token path', () => {
+            const g = new PathGraph();
+
+            // Single token path A->B->C but many rank combinations per hop
+            const abPools = Array.from({ length: 6 }, (_, i) =>
+                createMockPool(`pAB${i}`, [tokenA, tokenB], { getNormalizedLiquidity: () => BigInt(1000 - i) }),
+            );
+            const bcPools = Array.from({ length: 6 }, (_, i) =>
+                createMockPool(`pBC${i}`, [tokenB, tokenC], { getNormalizedLiquidity: () => BigInt(1000 - i) }),
+            );
+
+            g.buildGraph({
+                pools: [...abPools, ...bcPools],
+                enableAddRemoveLiquidityPaths: false,
+                maxPathsPerTokenPair: 6,
+            });
+
+            const paths = g.getCandidatePaths({
+                tokenIn: tokenA,
+                tokenOut: tokenC,
+                swapAmount: TokenAmount.fromRawAmount(tokenA, 1_000n),
+                swapKind: SwapKind.GivenIn,
+                graphTraversalConfig: {
+                    ...baseConfig,
+                    approxPathsToReturn: 5,
+                    maxRanksPerSegment: 6,
+                    minSwapAmountRatio: 0.0, // keep threshold minimal so many ranks qualify
+                },
+            });
+
+            // Because there is only one token path, this should not exceed approxPathsToReturn.
+            expect(paths.length).toBeLessThanOrEqual(5);
+            expect(paths.length).toBeGreaterThan(0);
+        });
+    });
+});

--- a/modules/sor/lib/pathGraph/pathGraph.test.ts
+++ b/modules/sor/lib/pathGraph/pathGraph.test.ts
@@ -1,7 +1,7 @@
 import { PathGraph } from './pathGraph';
 import { BasePool } from '../poolsV2/basePool';
 import { Token, TokenAmount, SwapKind } from '@balancer/sdk';
-import { describe, test, expect, mock, spyOn, beforeEach } from 'bun:test';
+import { describe, test, expect, beforeEach } from 'bun:test';
 
 const baseConfig = {
     maxDepth: 6,
@@ -11,6 +11,7 @@ const baseConfig = {
     approxPathsToReturn: 20,
     maxRanksPerSegment: 2,
     minSwapAmountRatio: 0.5,
+    maxTokenPaths: 5,
 };
 
 function createMockPool(id: string, tokens: Token[], opts: Partial<BasePool> = {}): BasePool {
@@ -31,7 +32,6 @@ describe('PathGraph search algorithms', () => {
     const tokenB = new Token(1, '0xb', 18);
     const tokenC = new Token(1, '0xc', 18);
     const tokenD = new Token(1, '0xd', 18);
-    const tokenE = new Token(1, '0xe', 18); // extra token for extended tests
 
     let pools: BasePool[];
     let graph: PathGraph;
@@ -81,7 +81,7 @@ describe('PathGraph search algorithms', () => {
             tokenIn: tokenA.wrapped,
             tokenOut: tokenD.wrapped,
             tokenPath: [tokenA.wrapped],
-            config: { ...baseConfig, maxDepth: 2, maxNonBoostedPathDepth: 2, maxNonBoostedHopTokensInBoostedPath: 1 },
+            config: { ...baseConfig, maxDepth: 2 },
         });
 
         // Only A -> D (buffer pool) should be valid, not A -> B -> C -> D

--- a/modules/sor/lib/pathGraph/pathGraph.ts
+++ b/modules/sor/lib/pathGraph/pathGraph.ts
@@ -84,9 +84,8 @@ export class PathGraph {
 
         // apply defaults, allowing caller override whatever they'd like
         const config: PathGraphTraversalConfig = {
-            maxDepth: 6,
-            maxNonBoostedPathDepth: 3,
-            maxNonBoostedHopTokensInBoostedPath: 2,
+            maxDepth: 4,
+            maxTokenPaths: 100,
             maxBuffersInPath: isHyperEvm ? 2 : 5, // limited only on HyperEvm due to gas cost limits on small blocks - virtually unlimited otherwise
             approxPathsToReturn: 20, // Default to 20 - likely won't be reached, but acts as a bound to the computation if needed
             maxRanksPerSegment: 2, // Default 2 for diversity
@@ -355,37 +354,13 @@ export class PathGraph {
     private isValidTokenPath({
         tokenPath,
         config,
-        tokenIn,
-        tokenOut,
     }: {
         tokenPath: string[];
         config: PathGraphTraversalConfig;
         tokenIn: string;
         tokenOut: string;
     }) {
-        const isCompletePath = tokenPath[tokenPath.length - 1] === tokenOut;
-        const hopTokens = tokenPath.filter((token) => token !== tokenIn && token !== tokenOut);
-        const numStandardHopTokens = hopTokens.filter((token) => !this.poolAddressMap.has(token)).length;
-        const isBoostedPath = tokenPath.filter((token) => this.poolAddressMap.has(token)).length > 0;
-
         if (tokenPath.length > config.maxDepth) {
-            return false;
-        }
-
-        if (isBoostedPath && numStandardHopTokens > config.maxNonBoostedHopTokensInBoostedPath) {
-            return false;
-        }
-
-        // if the path length is greater than maxNonBoostedPathDepth, then this path
-        // will only be valid if its a boosted path, so it must honor maxNonBoostedHopTokensInBoostedPath
-        if (
-            tokenPath.length > config.maxNonBoostedPathDepth &&
-            numStandardHopTokens > config.maxNonBoostedHopTokensInBoostedPath
-        ) {
-            return false;
-        }
-
-        if (isCompletePath && !isBoostedPath && tokenPath.length > config.maxNonBoostedPathDepth) {
             return false;
         }
 

--- a/modules/sor/lib/pathGraph/pathGraph.ts
+++ b/modules/sor/lib/pathGraph/pathGraph.ts
@@ -27,10 +27,17 @@ export class PathGraph {
         pools,
         maxPathsPerTokenPair = DEFAULT_MAX_PATHS_PER_TOKEN_PAIR,
         enableAddRemoveLiquidityPaths,
+        // Optional extras ignored in this implementation
+        swapKind,
+        tokenPrices,
+        minLimitThresholdUSD,
     }: {
         pools: BasePool[];
         maxPathsPerTokenPair?: number;
         enableAddRemoveLiquidityPaths: boolean;
+        swapKind?: SwapKind;
+        tokenPrices?: Map<string, number>;
+        minLimitThresholdUSD?: number;
     }) {
         this.poolAddressMap = new Map();
         this.nodes = new Map();
@@ -63,12 +70,15 @@ export class PathGraph {
         swapAmount,
         swapKind,
         graphTraversalConfig,
+        // Optional USD threshold hint ignored in this implementation
+        minLimitThresholdUSD,
     }: {
         tokenIn: Token;
         tokenOut: Token;
         swapAmount: TokenAmount;
         swapKind: SwapKind;
         graphTraversalConfig?: Partial<PathGraphTraversalConfig>;
+        minLimitThresholdUSD?: number;
     }): PathLocal[] {
         const isHyperEvm = tokenIn.chainId === 999;
 

--- a/modules/sor/lib/pathGraph/pathGraphTypes.ts
+++ b/modules/sor/lib/pathGraph/pathGraphTypes.ts
@@ -34,8 +34,7 @@ export interface PathGraphEdge extends PathGraphEdgeLabel {
 
 export interface PathGraphTraversalConfig {
     maxDepth: number;
-    maxNonBoostedPathDepth: number;
-    maxNonBoostedHopTokensInBoostedPath: number;
+    maxTokenPaths: number;
     maxBuffersInPath: number;
     approxPathsToReturn: number;
     minSwapAmountRatio: number;

--- a/modules/sor/lib/pathGraph/pathGraphTypes.ts
+++ b/modules/sor/lib/pathGraph/pathGraphTypes.ts
@@ -49,4 +49,7 @@ export interface PathGraphEdgeData {
     tokenIn: Token;
     tokenOut: Token;
     isBuffer: boolean;
+    // Optional USD-denominated optimistic limit for this edge for the active swapKind
+    // Defined only in beam graph when prices are available
+    limitUSD?: number;
 }

--- a/modules/sor/lib/pathGraph/performance/benchmark.ts
+++ b/modules/sor/lib/pathGraph/performance/benchmark.ts
@@ -1,0 +1,362 @@
+/**
+ * Performance benchmark script for PathGraph implementations.
+ *
+ * Compares PathGraph vs PathGraphBeam across different:
+ * - Graph sizes (small to xlarge)
+ * - Network topologies (hub-spoke, dense-mesh, etc.)
+ * - Configuration profiles (conservative vs aggressive)
+ *
+ * Measures build time, pathfinding speed, memory usage, and path quality.
+ * Run with: bun run modules/sor/lib/pathGraph/performance/benchmark.ts
+ *
+ * or to get the memory usage, but that's still wonky
+ *
+ * npx tsx modules/sor/lib/pathGraph/performance/benchmark.ts
+ */
+
+import { PathGraph } from '../pathGraph';
+import { PathGraphBeam } from '../pathGraph-beam';
+import { BasePool } from '../../poolsV2/basePool';
+import { Token, TokenAmount, SwapKind } from '@balancer/sdk';
+import { topologies } from './helpers';
+
+// Performance benchmark configuration
+const BENCHMARK_CONFIG = {
+    // Graph sizes to test
+    graphSizes: {
+        // tiny: { tokens: 20, pools: 30 },
+        small: { tokens: 100, pools: 200 },
+        // medium: { tokens: 300, pools: 800 },
+        // large: { tokens: 600, pools: 2000 },
+        xlarge: { tokens: 1000, pools: 4000 },
+    },
+    // Number of runs for statistical significance
+    benchmarkRuns: 2,
+    // Number of different token pairs to test per graph
+    tokenPairTests: 10,
+    // Test configurations
+    testConfigs: [
+        {
+            name: 'conservative',
+            config: {
+                maxDepth: 4,
+                maxTokenPaths: 20,
+                approxPathsToReturn: 10,
+                maxRanksPerSegment: 2,
+                minSwapAmountRatio: 0.5,
+                maxBuffersInPath: 3,
+            },
+        },
+        {
+            name: 'aggressive',
+            config: {
+                maxDepth: 6,
+                maxTokenPaths: 100,
+                approxPathsToReturn: 50,
+                maxRanksPerSegment: 4,
+                minSwapAmountRatio: 0.1,
+                maxBuffersInPath: 8,
+            },
+        },
+    ],
+};
+
+interface BenchmarkResult {
+    implementation: string;
+    graphSize: string;
+    topology: string;
+    configName: string;
+    tokenCount: number;
+    poolCount: number;
+    buildGraphTime: number;
+    avgPathfindingTime: number;
+    medianPathfindingTime: number;
+    p95PathfindingTime: number;
+    minPathfindingTime: number;
+    maxPathfindingTime: number;
+    totalPaths: number;
+    avgPathsPerQuery: number;
+    successfulQueries: number;
+    failedQueries: number;
+    memoryUsageKB?: number;
+}
+
+function percentile(arr: number[], p: number): number {
+    const sorted = arr.slice().sort((a, b) => a - b);
+    const index = Math.ceil((p / 100) * sorted.length) - 1;
+    return sorted[Math.max(0, index)];
+}
+
+async function benchmarkImplementation(
+    ImplementationClass: typeof PathGraph | typeof PathGraphBeam,
+    implementationName: string,
+    tokens: Token[],
+    pools: BasePool[],
+    topology: string,
+    graphSize: string,
+    configName: string,
+    testConfig: any,
+): Promise<BenchmarkResult> {
+    const graph = new ImplementationClass();
+
+    // Measure memory before
+    const memBefore = process.memoryUsage();
+
+    // Time graph building
+    const buildStart = performance.now();
+    graph.buildGraph({ pools, enableAddRemoveLiquidityPaths: false });
+    const buildEnd = performance.now();
+    const buildGraphTime = buildEnd - buildStart;
+
+    // Measure memory after graph building
+    const memAfter = process.memoryUsage();
+    const memoryUsageKB = (memAfter.heapUsed - memBefore.heapUsed) / 1024;
+
+    // Generate diverse token pairs
+    const tokenPairs: { tokenIn: Token; tokenOut: Token }[] = [];
+
+    // Add some random pairs
+    for (let i = 0; i < BENCHMARK_CONFIG.tokenPairTests; i++) {
+        const tokenIn = tokens[Math.floor(Math.random() * tokens.length)];
+        const tokenOut = tokens[Math.floor(Math.random() * tokens.length)];
+
+        if (tokenIn !== tokenOut) {
+            tokenPairs.push({ tokenIn, tokenOut });
+        }
+    }
+
+    // Benchmark pathfinding
+    const pathfindingTimes: number[] = [];
+    let totalPaths = 0;
+    let successfulQueries = 0;
+    let failedQueries = 0;
+
+    for (const { tokenIn, tokenOut } of tokenPairs) {
+        for (let run = 0; run < BENCHMARK_CONFIG.benchmarkRuns; run++) {
+            const swapAmount = TokenAmount.fromRawAmount(tokenIn, BigInt(Math.floor(Math.random() * 1000000) + 10000));
+
+            const startTime = performance.now();
+
+            try {
+                const paths = graph.getCandidatePaths({
+                    tokenIn,
+                    tokenOut,
+                    swapAmount,
+                    swapKind: SwapKind.GivenIn,
+                    graphTraversalConfig: testConfig,
+                });
+
+                const endTime = performance.now();
+                pathfindingTimes.push(endTime - startTime);
+                totalPaths += paths.length;
+                successfulQueries++;
+            } catch {
+                const endTime = performance.now();
+                pathfindingTimes.push(endTime - startTime);
+                failedQueries++;
+            }
+        }
+    }
+
+    const avgPathfindingTime = pathfindingTimes.reduce((sum, time) => sum + time, 0) / pathfindingTimes.length;
+    const medianPathfindingTime = percentile(pathfindingTimes, 50);
+    const p95PathfindingTime = percentile(pathfindingTimes, 95);
+    const minPathfindingTime = Math.min(...pathfindingTimes);
+    const maxPathfindingTime = Math.max(...pathfindingTimes);
+    const avgPathsPerQuery = successfulQueries > 0 ? totalPaths / successfulQueries : 0;
+
+    return {
+        implementation: implementationName,
+        graphSize,
+        topology,
+        configName,
+        tokenCount: tokens.length,
+        poolCount: pools.length,
+        buildGraphTime,
+        avgPathfindingTime,
+        medianPathfindingTime,
+        p95PathfindingTime,
+        minPathfindingTime,
+        maxPathfindingTime,
+        totalPaths,
+        avgPathsPerQuery,
+        successfulQueries,
+        failedQueries,
+        memoryUsageKB,
+    };
+}
+
+function printDetailedResults(results: BenchmarkResult[]): void {
+    console.log('\n' + '='.repeat(80));
+    console.log('🚀 PATHGRAPH PERFORMANCE BENCHMARK RESULTS');
+    console.log('='.repeat(80));
+
+    // Group by topology only, then by size and config
+    const topologyGroups = results.reduce(
+        (acc, result) => {
+            if (!acc[result.topology]) acc[result.topology] = {};
+            const sizeConfigKey = `${result.graphSize}-${result.configName}`;
+            if (!acc[result.topology][sizeConfigKey]) acc[result.topology][sizeConfigKey] = [];
+            acc[result.topology][sizeConfigKey].push(result);
+            return acc;
+        },
+        {} as Record<string, Record<string, BenchmarkResult[]>>,
+    );
+
+    console.log('\n**PathGraphBeam vs PathGraph Performance:**\n');
+
+    for (const [topology, sizeConfigGroups] of Object.entries(topologyGroups)) {
+        const displayTopology = topology
+            .split('-')
+            .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+            .join('-');
+
+        console.log(`${displayTopology} topology:`);
+
+        // Group by graph size to show all sizes for this topology
+        const sizeGroups: Record<string, Record<string, BenchmarkResult[]>> = {};
+        for (const [sizeConfigKey, groupResults] of Object.entries(sizeConfigGroups)) {
+            const [graphSize, configName] = sizeConfigKey.split('-');
+            if (!sizeGroups[graphSize]) sizeGroups[graphSize] = {};
+            sizeGroups[graphSize][configName] = groupResults;
+        }
+
+        for (const [graphSize, configGroups] of Object.entries(sizeGroups)) {
+            // Get token/pool count from any result in this size group
+            const sampleResult = Object.values(configGroups)[0][0];
+            console.log(`* ${graphSize} (${sampleResult.tokenCount} tokens, ${sampleResult.poolCount} pools):`);
+
+            for (const [configName, groupResults] of Object.entries(configGroups)) {
+                const beam = groupResults.find((r) => r.implementation === 'PathGraphBeam');
+                const original = groupResults.find((r) => r.implementation === 'PathGraph');
+
+                if (!beam || !original) continue;
+
+                const speedup = original.avgPathfindingTime / beam.avgPathfindingTime;
+                const winner = speedup >= 1.05 ? 'Beam' : speedup <= 0.95 ? 'Original' : 'Tie';
+
+                if (winner === 'Beam') {
+                    console.log(
+                        `  - ${configName.charAt(0).toUpperCase() + configName.slice(1)}: Beam ${speedup.toFixed(2)}x faster (${beam.avgPathfindingTime.toFixed(2)}ms vs ${original.avgPathfindingTime.toFixed(2)}ms)`,
+                    );
+                } else if (winner === 'Original') {
+                    console.log(
+                        `  - ${configName.charAt(0).toUpperCase() + configName.slice(1)}: Original ${(1 / speedup).toFixed(2)}x faster (${original.avgPathfindingTime.toFixed(2)}ms vs ${beam.avgPathfindingTime.toFixed(2)}ms)`,
+                    );
+                } else {
+                    console.log(
+                        `  - ${configName.charAt(0).toUpperCase() + configName.slice(1)}: Tie (${beam.avgPathfindingTime.toFixed(2)}ms vs ${original.avgPathfindingTime.toFixed(2)}ms)`,
+                    );
+                }
+            }
+        }
+        console.log('');
+    }
+
+    // Overall summary
+    console.log('='.repeat(80));
+    console.log('📈 OVERALL PERFORMANCE SUMMARY');
+    console.log('='.repeat(80));
+
+    const beamResults = results.filter((r) => r.implementation === 'PathGraphBeam');
+    const originalResults = results.filter((r) => r.implementation === 'PathGraph');
+
+    if (beamResults.length > 0 && originalResults.length > 0) {
+        const avgBeamPathfinding = beamResults.reduce((sum, r) => sum + r.avgPathfindingTime, 0) / beamResults.length;
+        const avgOriginalPathfinding =
+            originalResults.reduce((sum, r) => sum + r.avgPathfindingTime, 0) / originalResults.length;
+        const avgBeamBuild = beamResults.reduce((sum, r) => sum + r.buildGraphTime, 0) / beamResults.length;
+        const avgOriginalBuild = originalResults.reduce((sum, r) => sum + r.buildGraphTime, 0) / originalResults.length;
+
+        const pathfindingSpeedup = avgOriginalPathfinding / avgBeamPathfinding;
+        const buildSpeedup = avgOriginalBuild / avgBeamBuild;
+
+        console.log(
+            `\n🏆 Winner: ${pathfindingSpeedup > 1.1 ? 'PathGraphBeam' : pathfindingSpeedup < 0.9 ? 'PathGraph' : 'Tie'} (pathfinding)`,
+        );
+        console.log(
+            `   Overall pathfinding speedup: ${Math.max(pathfindingSpeedup, 1 / pathfindingSpeedup).toFixed(2)}x`,
+        );
+        console.log(`   Overall build speedup: ${Math.max(buildSpeedup, 1 / buildSpeedup).toFixed(2)}x`);
+
+        const avgBeamPaths = beamResults.reduce((sum, r) => sum + r.avgPathsPerQuery, 0) / beamResults.length;
+        const avgOriginalPaths =
+            originalResults.reduce((sum, r) => sum + r.avgPathsPerQuery, 0) / originalResults.length;
+        console.log(`   Average paths found: Beam ${avgBeamPaths.toFixed(1)}, Original ${avgOriginalPaths.toFixed(1)}`);
+    }
+
+    console.log('\n✅ Benchmark completed successfully!\n');
+}
+
+async function main(): Promise<void> {
+    console.log('🔥 Starting PathGraph Performance Benchmark...\n');
+    console.log(`Configuration:`);
+    console.log(`- Graph sizes: ${Object.keys(BENCHMARK_CONFIG.graphSizes).join(', ')}`);
+    console.log(
+        `- Topologies: ${Object.keys(topologies)
+            .map((t) => t)
+            .join(', ')}`,
+    );
+    console.log(`- Benchmark runs per test: ${BENCHMARK_CONFIG.benchmarkRuns}`);
+    console.log(`- Token pair tests per graph: ${BENCHMARK_CONFIG.tokenPairTests}\n`);
+
+    const results: BenchmarkResult[] = [];
+
+    for (const [sizeKey, sizeConfig] of Object.entries(BENCHMARK_CONFIG.graphSizes)) {
+        for (const topology of Object.values(topologies)) {
+            for (const { name: configName, config: testConfig } of BENCHMARK_CONFIG.testConfigs) {
+                console.log(`\n🧪 Generating ${sizeKey} ${topology.name} graph (${configName} config)...`);
+
+                const { tokens, pools } = topology.generator(sizeConfig.tokens, sizeConfig.pools);
+                console.log(`   Generated: ${tokens.length} tokens, ${pools.length} pools`);
+
+                console.log(`   Testing PathGraphBeam...`);
+                const beamResult = await benchmarkImplementation(
+                    PathGraphBeam,
+                    'PathGraphBeam',
+                    tokens,
+                    pools,
+                    topology.name,
+                    sizeKey,
+                    configName,
+                    testConfig,
+                );
+                results.push(beamResult);
+                console.log(
+                    `   ✅ Beam: ${beamResult.avgPathfindingTime.toFixed(2)}ms avg, ${beamResult.successfulQueries} successful queries`,
+                );
+
+                console.log(`   Testing PathGraph...`);
+                const originalResult = await benchmarkImplementation(
+                    PathGraph,
+                    'PathGraph',
+                    tokens,
+                    pools,
+                    topology.name,
+                    sizeKey,
+                    configName,
+                    testConfig,
+                );
+                results.push(originalResult);
+                console.log(
+                    `   ✅ Original: ${originalResult.avgPathfindingTime.toFixed(2)}ms avg, ${originalResult.successfulQueries} successful queries`,
+                );
+
+                // Quick comparison
+                const speedup = originalResult.avgPathfindingTime / beamResult.avgPathfindingTime;
+                console.log(
+                    `   🚀 Speedup: ${speedup.toFixed(2)}x ${speedup > 1 ? '(Beam faster)' : '(Original faster)'}`,
+                );
+            }
+        }
+    }
+
+    printDetailedResults(results);
+}
+
+// Run the benchmark
+if (require.main === module) {
+    main().catch(console.error);
+}
+
+export { main, benchmarkImplementation, topologies, BENCHMARK_CONFIG };

--- a/modules/sor/lib/pathGraph/performance/helpers.ts
+++ b/modules/sor/lib/pathGraph/performance/helpers.ts
@@ -1,0 +1,226 @@
+import { BasePool } from '../../poolsV2/basePool';
+import { Token, TokenAmount } from '@balancer/sdk';
+
+export interface GraphTopology {
+    name: 'hub-spoke' | 'dense-mesh' | 'chain-bridges' | 'realistic-defi';
+    description: string;
+    generator: (tokenCount: number, poolCount: number) => { tokens: Token[]; pools: BasePool[] };
+}
+
+export interface GraphSpec {
+    name: string;
+    tokens: number;
+    pools: number;
+    type: GraphTopology['name'];
+}
+
+export const topologies: Record<GraphTopology['name'], GraphTopology> = {
+    'hub-spoke': {
+        name: 'hub-spoke',
+        description: 'Central hub with radiating spokes',
+        generator: (tokenCount: number, poolCount: number) => {
+            const tokens: Token[] = [];
+            const pools: BasePool[] = [];
+
+            // Hub token (WETH-like)
+            const hubToken = new Token(1, '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', 18);
+            tokens.push(hubToken);
+
+            // Spoke tokens
+            for (let i = 0; i < tokenCount - 1; i++) {
+                tokens.push(new Token(1, `0x${(0x1000 + i).toString(16).padStart(40, '0')}`, 18));
+            }
+
+            let poolsCreated = 0;
+
+            // Hub-to-spoke pools (high liquidity)
+            for (let i = 1; i < tokenCount && poolsCreated < poolCount; i++) {
+                pools.push(
+                    createMockPool(`hub-${i}`, [hubToken, tokens[i]], {
+                        getNormalizedLiquidity: () => BigInt(Math.floor(Math.random() * 5000) + 2000),
+                        getLimitAmountSwap: () => BigInt(Math.floor(Math.random() * 10000000) + 1000000),
+                    }),
+                );
+                poolsCreated++;
+            }
+
+            // Spoke-to-spoke pools (medium liquidity)
+            while (poolsCreated < poolCount && tokenCount > 2) {
+                const idx1 = 1 + Math.floor(Math.random() * (tokenCount - 1));
+                const idx2 = 1 + Math.floor(Math.random() * (tokenCount - 1));
+                if (idx1 !== idx2) {
+                    pools.push(
+                        createMockPool(`spoke-${poolsCreated}`, [tokens[idx1], tokens[idx2]], {
+                            getNormalizedLiquidity: () => BigInt(Math.floor(Math.random() * 1000) + 200),
+                            getLimitAmountSwap: () => BigInt(Math.floor(Math.random() * 5000000) + 500000),
+                        }),
+                    );
+                    poolsCreated++;
+                }
+            }
+
+            return { tokens, pools };
+        },
+    },
+    'dense-mesh': {
+        name: 'dense-mesh',
+        description: 'High connectivity mesh network',
+        generator: (tokenCount: number, poolCount: number) => {
+            const tokens: Token[] = [];
+            const pools: BasePool[] = [];
+
+            for (let i = 0; i < tokenCount; i++) {
+                tokens.push(new Token(1, `0x${(0x2000 + i).toString(16).padStart(40, '0')}`, 18));
+            }
+
+            const maxPossiblePools = (tokenCount * (tokenCount - 1)) / 2;
+            const actualPoolCount = Math.min(poolCount, maxPossiblePools);
+            const connections = new Set<string>();
+
+            while (connections.size < actualPoolCount) {
+                const i = Math.floor(Math.random() * tokenCount);
+                const j = Math.floor(Math.random() * tokenCount);
+
+                if (i !== j) {
+                    const key = [i, j].sort().join('-');
+                    if (!connections.has(key)) {
+                        connections.add(key);
+                        const liquidity = BigInt(Math.floor(Math.random() * 3000) + 100);
+                        pools.push(
+                            createMockPool(`mesh-${key}`, [tokens[i], tokens[j]], {
+                                getNormalizedLiquidity: () => liquidity,
+                                getLimitAmountSwap: () => liquidity * 1000n,
+                            }),
+                        );
+                    }
+                }
+            }
+
+            return { tokens, pools };
+        },
+    },
+    'chain-bridges': {
+        name: 'chain-bridges',
+        description: 'Token chains with bridge connections',
+        generator: (tokenCount: number, poolCount: number) => {
+            const tokens: Token[] = [];
+            const pools: BasePool[] = [];
+
+            for (let i = 0; i < tokenCount; i++) {
+                tokens.push(new Token(1, `0x${(0x3000 + i).toString(16).padStart(40, '0')}`, 18));
+            }
+
+            let poolsCreated = 0;
+
+            // Main chain
+            for (let i = 0; i < tokenCount - 1 && poolsCreated < poolCount; i++) {
+                pools.push(
+                    createMockPool(`chain-${i}`, [tokens[i], tokens[i + 1]], {
+                        getNormalizedLiquidity: () => BigInt(Math.floor(Math.random() * 2000) + 500),
+                        getLimitAmountSwap: () => BigInt(Math.floor(Math.random() * 8000000) + 1000000),
+                    }),
+                );
+                poolsCreated++;
+            }
+
+            // Bridge connections (skip ahead)
+            while (poolsCreated < poolCount) {
+                const start = Math.floor(Math.random() * (tokenCount - 3));
+                const skipDistance = Math.floor(Math.random() * 5) + 2;
+                const end = Math.min(start + skipDistance, tokenCount - 1);
+
+                pools.push(
+                    createMockPool(`bridge-${poolsCreated}`, [tokens[start], tokens[end]], {
+                        getNormalizedLiquidity: () => BigInt(Math.floor(Math.random() * 1500) + 300),
+                        getLimitAmountSwap: () => BigInt(Math.floor(Math.random() * 6000000) + 800000),
+                    }),
+                );
+                poolsCreated++;
+            }
+
+            return { tokens, pools };
+        },
+    },
+    'realistic-defi': {
+        name: 'realistic-defi',
+        description: 'Simulates realistic DeFi token distribution',
+        generator: (tokenCount: number, poolCount: number) => {
+            const tokens: Token[] = [];
+            const pools: BasePool[] = [];
+
+            // Major tokens (ETH, USDC, USDT, DAI, WBTC equivalent)
+            const majorTokens = [
+                new Token(1, '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', 18), // WETH
+                new Token(1, '0xA0b86a33E6441942b3B9F1c882e6F2A5A86E1B5F', 6), // USDC-like
+                new Token(1, '0xdAC17F958D2ee523a2206206994597C13D831ec7', 6), // USDT-like
+                new Token(1, '0x6B175474E89094C44Da98b954EedeAC495271d0F', 18), // DAI-like
+                new Token(1, '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599', 8), // WBTC-like
+            ];
+
+            tokens.push(...majorTokens.slice(0, Math.min(5, tokenCount)));
+
+            // Add remaining tokens as smaller altcoins
+            for (let i = majorTokens.length; i < tokenCount; i++) {
+                tokens.push(new Token(1, `0x${(0x4000 + i).toString(16).padStart(40, '0')}`, 18));
+            }
+
+            let poolsCreated = 0;
+
+            // Major-to-major pairs (highest liquidity)
+            for (let i = 0; i < Math.min(5, tokens.length) && poolsCreated < poolCount; i++) {
+                for (let j = i + 1; j < Math.min(5, tokens.length) && poolsCreated < poolCount; j++) {
+                    pools.push(
+                        createMockPool(`major-${i}-${j}`, [tokens[i], tokens[j]], {
+                            getNormalizedLiquidity: () => BigInt(Math.floor(Math.random() * 10000) + 5000),
+                            getLimitAmountSwap: () => BigInt(Math.floor(Math.random() * 50000000) + 10000000),
+                            poolType: Math.random() > 0.5 ? 'Weighted' : 'Stable',
+                        }),
+                    );
+                    poolsCreated++;
+                }
+            }
+
+            // Major-to-altcoin pairs (medium liquidity)
+            for (let i = 5; i < tokens.length && poolsCreated < poolCount; i++) {
+                const majorIdx = Math.floor(Math.random() * Math.min(5, tokens.length));
+                pools.push(
+                    createMockPool(`major-alt-${i}`, [tokens[majorIdx], tokens[i]], {
+                        getNormalizedLiquidity: () => BigInt(Math.floor(Math.random() * 2000) + 200),
+                        getLimitAmountSwap: () => BigInt(Math.floor(Math.random() * 10000000) + 1000000),
+                    }),
+                );
+                poolsCreated++;
+            }
+
+            // Altcoin-to-altcoin pairs (low liquidity)
+            while (poolsCreated < poolCount && tokens.length > 5) {
+                const i = 5 + Math.floor(Math.random() * (tokens.length - 5));
+                const j = 5 + Math.floor(Math.random() * (tokens.length - 5));
+                if (i !== j) {
+                    pools.push(
+                        createMockPool(`alt-alt-${poolsCreated}`, [tokens[i], tokens[j]], {
+                            getNormalizedLiquidity: () => BigInt(Math.floor(Math.random() * 500) + 50),
+                            getLimitAmountSwap: () => BigInt(Math.floor(Math.random() * 2000000) + 100000),
+                        }),
+                    );
+                    poolsCreated++;
+                }
+            }
+
+            return { tokens, pools };
+        },
+    },
+};
+
+function createMockPool(id: string, tokens: Token[], opts: Partial<BasePool> = {}): BasePool {
+    return {
+        id,
+        address: id.startsWith('0x') ? id : `0x${id.padEnd(40, '0')}`,
+        poolType: opts.poolType ?? 'Weighted',
+        tokens: tokens.map((t) => ({ token: t })),
+        getNormalizedLiquidity: opts.getNormalizedLiquidity ?? (() => 100n),
+        getLimitAmountSwap: opts.getLimitAmountSwap ?? (() => 1_000_000n),
+        swapGivenOut: opts.swapGivenOut ?? ((_in: Token, _out: Token, amt: TokenAmount) => amt),
+        ...opts,
+    } as unknown as BasePool;
+}

--- a/modules/sor/lib/pathGraph/performance/tune-params.ts
+++ b/modules/sor/lib/pathGraph/performance/tune-params.ts
@@ -1,0 +1,187 @@
+#!/usr/bin/env bun
+
+/**
+ * Parameter tuning script for PathGraphBeam optimization.
+ *
+ * Tests various parameter combinations across different graph sizes and topologies
+ * to find optimal settings for:
+ * - maxDepth, maxTokenPaths, approxPathsToReturn
+ * - maxRanksPerSegment, minSwapAmountRatio
+ *
+ * Outputs fastest, most-paths, and balanced configurations for each test case.
+ * Run with: bun run modules/sor/lib/pathGraph/performance/tune-params.ts
+ */
+
+import { PathGraphBeam } from '../pathGraph-beam';
+import { BasePool } from '../../poolsV2/basePool';
+import { Token, TokenAmount, SwapKind } from '@balancer/sdk';
+import { topologies, GraphSpec } from './helpers';
+
+interface ParamSet {
+    maxDepth: number;
+    maxTokenPaths: number;
+    approxPathsToReturn: number;
+    maxRanksPerSegment: number;
+    minSwapAmountRatio: number;
+}
+
+interface TuneResult {
+    params: string;
+    avgTimeMs: number;
+    pathsFound: number;
+    successRate: number;
+}
+
+// Focused parameter grid - most impactful parameters only
+const PARAM_GRID = {
+    maxDepth: [3, 4, 5],
+    maxTokenPaths: [10, 25, 50],
+    approxPathsToReturn: [5, 10, 20],
+    maxRanksPerSegment: [1, 2, 3],
+    minSwapAmountRatio: [0.1, 0.3, 0.5],
+};
+
+const GRAPHS: GraphSpec[] = [
+    { name: 'tiny-hub', tokens: 20, pools: 30, type: 'hub-spoke' },
+    { name: 'tiny-mesh', tokens: 20, pools: 40, type: 'dense-mesh' },
+    { name: 'small-hub', tokens: 50, pools: 80, type: 'hub-spoke' },
+    { name: 'small-mesh', tokens: 50, pools: 120, type: 'dense-mesh' },
+    { name: 'med-hub', tokens: 100, pools: 200, type: 'hub-spoke' },
+    { name: 'med-mesh', tokens: 100, pools: 300, type: 'dense-mesh' },
+];
+
+async function testParams(graph: { tokens: Token[]; pools: BasePool[] }, params: ParamSet): Promise<TuneResult> {
+    const pathGraph = new PathGraphBeam();
+    pathGraph.buildGraph({ pools: graph.pools, enableAddRemoveLiquidityPaths: false });
+
+    const testPairs = 3;
+    const runs = 2;
+    const times: number[] = [];
+    let totalPaths = 0;
+    let successful = 0;
+    let total = 0;
+
+    for (let pair = 0; pair < testPairs; pair++) {
+        const tokenIn = graph.tokens[Math.floor(Math.random() * graph.tokens.length)];
+        const tokenOut = graph.tokens[Math.floor(Math.random() * graph.tokens.length)];
+
+        if (tokenIn === tokenOut) continue;
+
+        for (let run = 0; run < runs; run++) {
+            const amount = TokenAmount.fromRawAmount(tokenIn, BigInt(Math.floor(100000 + Math.random() * 900000)));
+
+            const start = performance.now();
+            try {
+                const paths = pathGraph.getCandidatePaths({
+                    tokenIn,
+                    tokenOut,
+                    swapAmount: amount,
+                    swapKind: SwapKind.GivenIn,
+                    graphTraversalConfig: {
+                        ...params,
+                        maxBuffersInPath: 5,
+                    },
+                });
+
+                times.push(performance.now() - start);
+                totalPaths += paths.length;
+                successful++;
+            } catch {
+                times.push(performance.now() - start);
+            }
+            total++;
+        }
+    }
+
+    const avgTime = times.reduce((s, t) => s + t, 0) / times.length;
+    const avgPaths = successful > 0 ? totalPaths / successful : 0;
+    const successRate = successful / total;
+
+    const paramsStr = `d${params.maxDepth}t${params.maxTokenPaths}p${params.approxPathsToReturn}r${params.maxRanksPerSegment}s${params.minSwapAmountRatio}`;
+
+    return {
+        params: paramsStr,
+        avgTimeMs: avgTime,
+        pathsFound: avgPaths,
+        successRate,
+    };
+}
+
+function generateParamCombinations(): ParamSet[] {
+    const combinations: ParamSet[] = [];
+
+    // Generate strategic combinations instead of full grid
+    // Speed-focused configs
+    combinations.push(
+        { maxDepth: 3, maxTokenPaths: 10, approxPathsToReturn: 5, maxRanksPerSegment: 1, minSwapAmountRatio: 0.5 },
+        { maxDepth: 3, maxTokenPaths: 25, approxPathsToReturn: 10, maxRanksPerSegment: 1, minSwapAmountRatio: 0.3 },
+    );
+
+    // Balanced configs
+    combinations.push(
+        { maxDepth: 4, maxTokenPaths: 25, approxPathsToReturn: 10, maxRanksPerSegment: 2, minSwapAmountRatio: 0.3 },
+        { maxDepth: 4, maxTokenPaths: 50, approxPathsToReturn: 20, maxRanksPerSegment: 2, minSwapAmountRatio: 0.1 },
+        { maxDepth: 5, maxTokenPaths: 25, approxPathsToReturn: 10, maxRanksPerSegment: 2, minSwapAmountRatio: 0.3 },
+    );
+
+    // Quality-focused configs
+    combinations.push(
+        { maxDepth: 5, maxTokenPaths: 50, approxPathsToReturn: 20, maxRanksPerSegment: 3, minSwapAmountRatio: 0.1 },
+        { maxDepth: 4, maxTokenPaths: 50, approxPathsToReturn: 20, maxRanksPerSegment: 3, minSwapAmountRatio: 0.1 },
+    );
+
+    // Edge cases
+    combinations.push(
+        { maxDepth: 3, maxTokenPaths: 50, approxPathsToReturn: 20, maxRanksPerSegment: 1, minSwapAmountRatio: 0.1 },
+        { maxDepth: 5, maxTokenPaths: 10, approxPathsToReturn: 5, maxRanksPerSegment: 3, minSwapAmountRatio: 0.5 },
+    );
+
+    return combinations;
+}
+
+async function tuneGraph(spec: GraphSpec): Promise<void> {
+    const graph = topologies[spec.type].generator(spec.tokens, spec.pools);
+    const paramSets = generateParamCombinations();
+
+    console.log(`${spec.name}:`);
+
+    const results: TuneResult[] = [];
+
+    for (const params of paramSets) {
+        const result = await testParams(graph, params);
+        results.push(result);
+        console.log(
+            `  ${result.params} → ${result.avgTimeMs.toFixed(1)}ms ${result.pathsFound.toFixed(1)}p ${(result.successRate * 100).toFixed(0)}%`,
+        );
+    }
+
+    // Find best by different criteria
+    const fastest = results.sort((a, b) => a.avgTimeMs - b.avgTimeMs)[0];
+    const mostPaths = results.sort((a, b) => b.pathsFound - a.pathsFound)[0];
+    const balanced = results.sort((a, b) => {
+        const scoreA = (100 - a.avgTimeMs) * 0.6 + a.pathsFound * 0.4;
+        const scoreB = (100 - b.avgTimeMs) * 0.6 + b.pathsFound * 0.4;
+        return scoreB - scoreA;
+    })[0];
+
+    console.log(`  fastest: ${fastest.params}`);
+    console.log(`  most-paths: ${mostPaths.params}`);
+    console.log(`  balanced: ${balanced.params}`);
+}
+
+async function main(): Promise<void> {
+    console.log('Parameter Tuning Results');
+    console.log('Format: d=depth, t=tokenPaths, p=pathsReturn, r=ranksSegment, s=swapRatio');
+    console.log('Output: time(ms), paths, success%\n');
+
+    for (const spec of GRAPHS) {
+        await tuneGraph(spec);
+        console.log();
+    }
+}
+
+if (require.main === module) {
+    main().catch(console.error);
+}
+
+export { main, tuneGraph, PARAM_GRID };

--- a/modules/sor/lib/pathGraph/review.md
+++ b/modules/sor/lib/pathGraph/review.md
@@ -1,0 +1,295 @@
+Here’s a structured deep-dive into what your PathGraph does, the architecture and algorithms at play, and where I’d tune it for correctness, performance, and maintainability.
+
+Overview
+
+-   Purpose: Build a directed token graph from pools and enumerate candidate swap paths between tokenIn → tokenOut. Then, for each token path, choose concrete pools per hop using a greedy, rank-based search, pruning by pool limits and config constraints.
+-   Output: A set of PathLocal objects representing viable routes (token sequence + pool sequence + buffer flags), ready for a higher-level optimizer to decide splits.
+
+Architecture and data model
+
+-   Core data structures
+    -   nodes: Map<string, { isPhantomBpt: boolean }>
+        -   Keyed by token address (.wrapped). Marks tokens that are pool BPTs (isPhantomBpt).
+    -   edges: Map<string, Map<string, PathGraphEdgeData[]>>
+        -   Adjacency list. For each tokenIn, a map of tokenOut → a sorted array of candidate edges by normalizedLiquidity (top N per pair).
+        -   PathGraphEdgeData contains: pool, tokenIn, tokenOut, normalizedLiquidity, isBuffer.
+    -   poolAddressMap: Map<string, BasePool> for quick pool lookup by address.
+-   Build phases
+    1. Pool index: buildPoolAddressMap(pools)
+    2. Nodes: addAllTokensAsGraphNodes
+        - Optionally adds pool BPT tokens (enableAddRemoveLiquidityPaths).
+    3. Edges: addTokenPairsAsGraphEdges
+        - For each (tokenIn, tokenOut) pair within a pool, add an edge ranked by normalizedLiquidity.
+        - Enforces per-pair cap maxPathsPerTokenPair, except when pool BPT is involved (isPhantomBpt).
+-   Search phases
+    1. Find all valid token paths (sequence of token addresses) honoring constraints (depth, boosted/non-boosted).
+    2. For each token path, choose pool edges per hop via rank-search:
+        - expandTokenPathWithBestRanks prioritizes higher-liquidity ranks first, checks path-level limit early, and prunes.
+
+Key algorithms and where they’re used
+
+1. Graph building
+
+    - Edge ranking: “Top-K by normalizedLiquidity” per token pair. Internally, edges are kept sorted descending.
+    - Phantom/BPT handling: Edges that involve a BPT token can bypass the Top-K cap to avoid pruning boosted paths.
+
+2. Token path discovery
+
+    - traverseBfs: Despite the name, this is actually a depth-first recursive traversal (DFS), not BFS.
+    - Pruning rules inside isValidTokenPath:
+        - Max length (maxDepth).
+        - Non-boosted path depth cap (maxNonBoostedPathDepth).
+        - If the path includes any pool BPT tokens (“boosted”), restrict number of non-boosted hops (maxNonBoostedHopTokensInBoostedPath).
+        - No token revisited (checked before recursing).
+
+3. Pool rank combination for a token path
+
+    - expandTokenPathWithBestRanks:
+        - Treats each hop as having “ranks” 0..(k-1) by liquidity.
+        - Explores rank combinations via a queue of rank vectors (ranks[]), starting with all zeros (highest liquidity everywhere).
+        - For each rank vector:
+            - Build the concrete path (expandTokenPathWithRanks).
+            - Compute path limit (getLimitAmountSwapForPath) and keep it if it clears minLimitThreshold.
+            - Tracks “finalRanks” per segment as a stopping criterion to cap how many ranks you consider per segment (maxRanksPerSegment).
+        - Adds new candidates by incrementing one segment’s rank at a time (addAlternativeRanks).
+
+4. Capacity/limit computation for a path
+
+    - getLimitAmountSwapForPath
+        - Walk backward from the last hop to the first to compute the maximum feasible swap size for the whole path.
+        - For an intermediate hop, compares GivenOut and GivenIn limits, and if needed, calls swapGivenOut to “pull” the input required for the downstream cap.
+        - This effectively propagates the tightest capacity back to the path’s input.
+
+5. Final filtering
+    - sortAndFilterPaths:
+        - Computes per-path limit, sorts descending by limit.
+        - Attempts to remove paths that reuse any pool across the final selection and ensures no pool repeats within a path.
+
+Correctness notes and potential bugs
+
+-   traverseBfs is DFS
+
+    -   The function name is misleading. Either rename it to traverseDfs or implement a real BFS with a queue.
+
+-   sortAndFilterPaths “seenPools” scoping bug
+
+    -   The code resets seenPools to [] for every path in the loop, so you’re not actually preventing pool reuse across different selected paths.
+    -   Fix by keeping a Set outside the loop.
+    -   Suggested fix:
+
+        ```ts
+        private sortAndFilterPaths(paths: PathGraphEdgeData[][]): PathGraphEdgeData[][] {
+          const pathsWithLimits = paths
+            .map((path) => {
+              try {
+                const limit = this.getLimitAmountSwapForPath(path, SwapKind.GivenIn);
+                return { path, limit };
+              } catch {
+                return undefined;
+              }
+            })
+            .filter((x): x is { path: PathGraphEdgeData[]; limit: bigint } => !!x)
+            .sort((a, b) => (a.limit < b.limit ? 1 : -1));
+
+          const filtered: PathGraphEdgeData[][] = [];
+          const usedPools = new Set<string>(); // persist across selections
+
+          for (const { path } of pathsWithLimits) {
+            const pools = path.map((s) => s.pool.id);
+
+            // reject if path uses same pool twice
+            if (new Set(pools).size !== pools.length) continue;
+
+            // reject if any pool already used by a previously selected path
+            if (pools.some((p) => usedPools.has(p))) continue;
+
+            filtered.push(path);
+            pools.forEach((p) => usedPools.add(p));
+          }
+
+          return filtered;
+        }
+        ```
+
+-   isValidPath’s seenPoolAddresses is always []
+
+    -   In getCandidatePaths you pass seenPoolAddresses: [] and never update it, so that check never filters anything. Either remove this parameter or wire it up properly.
+
+-   getConnectedVertices return type mix
+
+    -   It does const edges = this.edges.get(tokenAddress) || []; then for (const [otherToken] of edges).
+    -   If edges is [], that loop is fine (no iterations), but the type is off and brittle.
+    -   Prefer:
+        ```ts
+        private getConnectedVertices(tokenAddress: string): string[] {
+          const edges = this.edges.get(tokenAddress);
+          if (!edges) return [];
+          return Array.from(edges.keys());
+        }
+        ```
+
+-   BPT/phantom detection inconsistency
+
+    -   nodes.set(... isPhantomBpt: !!this.poolAddressMap.get(token.wrapped)).
+    -   isValidTokenPath uses poolAddressMap.has(token) to detect “boosted.”
+    -   Consider using nodes.get(token).isPhantomBpt consistently, and differentiate “isBpt” from “isPhantomBpt” if you only want to bypass caps for phantom BPTs.
+
+-   expandTokenPathWithBestRanks control flow with exceptions
+
+    -   The code uses try/catch to detect missing ranks (edge[rank] undefined). This is control-flow via exceptions and will be costly.
+    -   Pre-check rank existence before enqueuing:
+        ```ts
+        // when pushing a newRanks candidate
+        const edgeCount = this.edges.get(tokenPath[segmentIndex])?.get(tokenPath[segmentIndex + 1])?.length ?? 0;
+        if (currentRank + 1 < edgeCount) {
+            // enqueue safely
+        }
+        ```
+
+-   finalRanks logic is fragile
+    -   It assumes segments are finalized in order (currentFinalRankIndex = finalRanks.length), which may not correlate to which segment’s ranks you’ve actually explored sufficiently.
+    -   Track per-segment state explicitly.
+
+Performance characteristics and complexity
+
+-   Graph building
+    -   addEdge sorts the edge array on every insertion (O(k log k)), where k ≤ maxPathsPerTokenPair. With many pools it adds up.
+-   Token path enumeration
+    -   Exponential in the worst case, bounded by:
+        -   maxDepth
+        -   maxNonBoostedPathDepth
+        -   boosted constraints
+        -   top-K edges per pair in graph construction
+-   Rank combination search
+    -   For a token path of length L, worst case explores up to min(maxRanksPerSegment, K)^L combinations (with pruning).
+    -   Each combination calls getLimitAmountSwapForPath, which is O(L) but involves BasePool computations per hop.
+
+Concrete improvements
+
+1. Fix correctness issues
+
+-   Rename traverseBfs → traverseDfs or implement BFS with a queue.
+-   Fix seenPools scoping bug in sortAndFilterPaths (see code above).
+-   Remove dead “seenPoolAddresses” parameter or make it effective (e.g., keep a Set across selection).
+-   Use nodes.get(token).isPhantomBpt consistently for boosted detection; optionally add a separate isBpt flag.
+
+2. Reduce sorting/insertion overhead when building edges
+
+-   Instead of sorting on every insertion:
+    -   Maintain a small “top-k” structure per pair:
+        ```ts
+        // Pseudo approach:
+        const arr = tokenInNode.get(tokenOut) ?? [];
+        insertIntoTopK(arr, edgeProps, k); // binary insert into sorted fixed-size array
+        tokenInNode.set(tokenOut, arr);
+        ```
+    -   Or batch edges per pair, then sort once and slice to k after processing all pools.
+
+3. Avoid exception-driven flow in expandTokenPathWithBestRanks
+
+-   Do not enqueue rank vectors that reference non-existent ranks. You can precompute edge counts for each segment and bound ranks accordingly.
+
+4. Make rank exploration more principled
+
+-   Use a priority queue (best-first) keyed by a heuristic. Examples:
+    -   Upper bound on path capacity: min of per-segment GivenIn capacity (fast to compute).
+    -   Or min(normalizedLiquidity) across segments as a cheap proxy.
+-   Replace finalRanks with per-segment caps tracked explicitly:
+
+    ```ts
+    const perSegmentMaxExploredRank = Array(numSegments).fill(-1);
+    const perSegmentUniqueRanks = Array.from({ length: numSegments }, () => new Set<number>());
+
+    // When accepting a path:
+    ranks.forEach((r, i) => {
+        perSegmentUniqueRanks[i].add(r);
+        if (perSegmentUniqueRanks[i].size >= maxRanksPerSegment) {
+            perSegmentMaxExploredRank[i] = Math.max(perSegmentMaxExploredRank[i], r);
+        }
+    });
+
+    // When enqueuing rank alternatives:
+    if (ranks[i] + 1 < Math.min(edgeCount[i], perSegmentMaxExploredRank[i] + 1 || Infinity)) {
+        // enqueue
+    }
+    ```
+
+5. Cache pool-level limits used inside getLimitAmountSwapForPath
+
+-   Per search call, memoize for each edge:
+    -   poolLimitExactIn = pool.getLimitAmountSwap(GivenIn)
+    -   poolLimitExactOut = pool.getLimitAmountSwap(GivenOut)
+-   This reduces repeated calls when evaluating many rank combinations for the same segments.
+    ```ts
+    const limitCache = new Map<string, { in: bigint; out: bigint }>();
+    const key = `${pool.id}-${tokenIn}-${tokenOut}`;
+    // fetch or compute once
+    ```
+
+6. Improve token path enumeration
+
+-   If you really want BFS behavior (shortest paths first), use a queue and layer-by-layer expansion. It often yields better early exits if you limit approxPathsToReturn.
+-   Additional pruning heuristics:
+    -   Early stop if the best possible edgeCount across remaining segments can’t reach minLimitThreshold (needs a simple upper-bound function).
+    -   Optional whitelist of “core” tokens to reduce the branching factor.
+
+7. Use Sets for membership checks and IDs
+
+-   selectedPathIds can be a Set<string> instead of an array for O(1) membership.
+-   During path validation, use Sets for pools/tokens to avoid repeated O(n) includes checks.
+
+8. Ratio arithmetic to BigInt
+
+-   minLimitThreshold uses floor(minSwapAmountRatio \* 100) / 100n. This loses precision for ratios not aligned to 1/100.
+-   Use basis points or bps×1e4:
+    ```ts
+    // e.g., if using 10_000 bps scaling
+    const bps = Math.round(config.minSwapAmountRatio * 10_000);
+    const minLimitThreshold = (swapAmount.amount * BigInt(bps)) / 10_000n;
+    ```
+
+9. Separate “isBPT” vs “isPhantomBPT”
+
+-   Your TODO suggests concern about v3. Track both flags:
+    -   isBpt: token address equals a pool address (BPT token node)
+    -   isPhantomBpt: specifically phantom
+-   Use isPhantomBpt only to bypass Top-K pruning. Use isBpt to apply boosted constraints.
+
+10. Observability
+
+-   Replace console.log in the catch with a debug logger and include pool/path IDs.
+-   Count/emit metrics: number of token paths explored, rank combos tried, pruned by limit, etc.
+
+Small code nits
+
+-   getConnectedVertices: return Array.from(map.keys()) as noted.
+-   addAlternativeRanks: bound by the actual edge counts per segment instead of this.maxPathsPerTokenPair.
+-   In getCandidatePaths, consider wiring an overall cap (e.g., stop once you’ve gathered enough qualified paths globally, not just per token path).
+
+What algorithms you’re effectively using
+
+-   Graph modeling + constrained DFS for simple paths (no repeated tokens).
+-   Top-K per pair edge reduction using normalizedLiquidity.
+-   Greedy/best-first-ish local search over rank combinations, with pruning by:
+    -   Early capacity limit check (minLimitThreshold)
+    -   Diversity cap per segment (maxRanksPerSegment)
+-   Backward limit propagation along a path to determine feasible swap size.
+
+When to consider heavier graph algorithms
+
+-   If you need more principled “best K simple paths” at the token level, consider:
+    -   Yen’s algorithm (K-shortest simple paths)
+    -   Eppstein’s algorithm (K-shortest paths efficiently)
+-   You’d still need to layer on pool-rank selection per hop, but token-level path enumeration would be more controlled and optimal.
+
+Summary of high-impact changes
+
+-   Fix sortAndFilterPaths pooled dedupe bug (Set outside loop).
+-   Make rank exploration safer (no exceptions, correct per-segment caps).
+-   Use Sets for selectedPathIds and validation membership.
+-   Reduce sort-on-insert overhead for edges (top-K maintenance).
+-   Add caching for pool limits during limit propagation.
+-   Rename traverseBfs or implement proper BFS for clarity and potential early termination benefits.
+-   Improve precision for minLimitThreshold computation.
+
+If you want, I can sketch a refactor of expandTokenPathWithBestRanks using a priority queue and per-segment caps, or a batched top-K edge construction that avoids sorting each time.

--- a/modules/sor/lib/router.ts
+++ b/modules/sor/lib/router.ts
@@ -52,6 +52,7 @@ export class Router {
             }
         }
 
+        const buildGraphStart = performance.now();
         this.pathGraph.buildGraph({
             pools,
             enableAddRemoveLiquidityPaths,
@@ -59,6 +60,8 @@ export class Router {
             tokenPrices,
             minLimitThresholdUSD,
         });
+        const buildGraphEnd = performance.now();
+        console.log(`SOR:buildGraph: ${(buildGraphEnd - buildGraphStart).toFixed(2)}ms`);
 
         const candidatePaths = this.pathGraph.getCandidatePaths({
             tokenIn,

--- a/modules/sor/lib/router.ts
+++ b/modules/sor/lib/router.ts
@@ -1,5 +1,7 @@
 import { SwapKind, Token, TokenAmount } from '@balancer/sdk';
 import { PathGraph } from './pathGraph/pathGraph';
+import { PathGraphBeam } from './pathGraph/pathGraph-beam';
+import { PathGraphBfs } from './pathGraph/pathGraph-proper-bfs';
 import { PathGraphTraversalConfig } from './pathGraph/pathGraphTypes';
 import { max, min } from './utils/math';
 import { BasePool } from './poolsV2/basePool';
@@ -8,12 +10,22 @@ import { parseEther } from 'viem';
 import { Chain } from '@prisma/client';
 import { chainToChainId } from '../../network/chain-id-to-chain';
 
+const pathGraphVersions = {
+    original: PathGraph,
+    beamOptimisation: PathGraphBeam,
+    bfsOptimisation: PathGraphBfs,
+};
+
+type PathGraphClass = PathGraph | PathGraphBeam | PathGraphBfs;
+
+export type PathGraphVersion = keyof typeof pathGraphVersions;
+
 const SWAPS_GREATER_THAN_BUFFER_LIMIT_THRESHOLD = 2;
 export class Router {
-    private readonly pathGraph: PathGraph;
+    private readonly pathGraph: PathGraphClass;
 
-    constructor() {
-        this.pathGraph = new PathGraph();
+    constructor(graphVersion: PathGraphVersion) {
+        this.pathGraph = new pathGraphVersions[graphVersion]();
     }
 
     public getCandidatePaths(

--- a/modules/sor/lib/router.ts
+++ b/modules/sor/lib/router.ts
@@ -6,7 +6,9 @@ import { PathGraphTraversalConfig } from './pathGraph/pathGraphTypes';
 import { max, min } from './utils/math';
 import { BasePool } from './poolsV2/basePool';
 import { PathLocal, PathWithAmount } from './path';
-import { parseEther } from 'viem';
+import { formatUnits, parseEther } from 'viem';
+import { tokenService } from '../../token/token.service';
+import { chainIdToChain } from '../../network/chain-id-to-chain';
 import { Chain } from '@prisma/client';
 import { chainToChainId } from '../../network/chain-id-to-chain';
 
@@ -35,9 +37,28 @@ export class Router {
         swapAmount: TokenAmount,
         swapKind: SwapKind,
         enableAddRemoveLiquidityPaths: boolean,
+        tokenPrices: Map<string, number>,
         graphTraversalConfig?: Partial<PathGraphTraversalConfig>,
     ): PathLocal[] {
-        this.pathGraph.buildGraph({ pools, enableAddRemoveLiquidityPaths });
+        // Compute USD threshold if prices provided
+        let minLimitThresholdUSD: number | undefined = undefined;
+        if (graphTraversalConfig?.minSwapAmountRatio !== undefined && tokenPrices) {
+            const ratio = Math.max(0, Math.min(1, graphTraversalConfig.minSwapAmountRatio));
+            const priceToken = swapKind === SwapKind.GivenIn ? tokenIn : tokenOut;
+            const price = tokenPrices.get(priceToken.wrapped.toLowerCase());
+            if (price !== undefined) {
+                const amount = Number(formatUnits(swapAmount.amount, priceToken.decimals));
+                minLimitThresholdUSD = amount * ratio * price;
+            }
+        }
+
+        this.pathGraph.buildGraph({
+            pools,
+            enableAddRemoveLiquidityPaths,
+            swapKind,
+            tokenPrices,
+            minLimitThresholdUSD,
+        });
 
         const candidatePaths = this.pathGraph.getCandidatePaths({
             tokenIn,
@@ -45,6 +66,7 @@ export class Router {
             swapAmount,
             swapKind,
             graphTraversalConfig,
+            minLimitThresholdUSD,
         });
 
         return candidatePaths;

--- a/modules/sor/lib/sor.ts
+++ b/modules/sor/lib/sor.ts
@@ -37,9 +37,12 @@ export class SOR {
         prismaPools: PrismaPoolAndHookWithDynamic[],
         bufferPools: BufferPoolData[],
         protocolVersion: number,
+        tokenPrices: Map<string, number>,
         swapOptions?: Omit<SorSwapOptions, 'graphTraversalConfig.poolIdsToInclude'>,
         graphVersion: PathGraphVersion = 'original',
     ): Promise<PathWithAmount[] | null> {
+        const sorStart = performance.now();
+
         const checkedSwapAmount = checkInputs(tokenIn, tokenOut, swapKind, swapAmountEvm);
 
         // get current block timestamp if not provided
@@ -154,6 +157,7 @@ export class SOR {
             checkedSwapAmount,
             swapKind,
             protocolVersion === 3,
+            tokenPrices,
             swapOptions?.graphTraversalConfig,
         );
 
@@ -162,6 +166,9 @@ export class SOR {
         const bestPaths = router.getBestPaths(candidatePaths, swapKind, checkedSwapAmount);
 
         if (!bestPaths) return null;
+
+        const sorEnd = performance.now();
+        console.log(`SOR:getPathsWithPools: ${(sorEnd - sorStart).toFixed(2)}ms`);
 
         return bestPaths;
     }

--- a/modules/sor/lib/sor.ts
+++ b/modules/sor/lib/sor.ts
@@ -150,6 +150,8 @@ export class SOR {
 
         const router = new Router(graphVersion);
 
+        // time router.getCandidatePaths
+        const candidatePathsStart = performance.now();
         const candidatePaths = router.getCandidatePaths(
             tokenIn,
             tokenOut,
@@ -160,10 +162,16 @@ export class SOR {
             tokenPrices,
             swapOptions?.graphTraversalConfig,
         );
+        const candidatePathsEnd = performance.now();
+        console.log(`SOR:getCandidatePaths: ${(candidatePathsEnd - candidatePathsStart).toFixed(2)}ms`);
 
         if (candidatePaths.length === 0) return null;
 
+        // time router.getBestPaths
+        const bestPathsStart = performance.now();
         const bestPaths = router.getBestPaths(candidatePaths, swapKind, checkedSwapAmount);
+        const bestPathsEnd = performance.now();
+        console.log(`SOR:getBestPaths: ${(bestPathsEnd - bestPathsStart).toFixed(2)}ms`);
 
         if (!bestPaths) return null;
 

--- a/modules/sor/lib/sor.ts
+++ b/modules/sor/lib/sor.ts
@@ -1,6 +1,6 @@
 import { SwapKind, Token } from '@balancer/sdk';
 
-import { Router } from './router';
+import { Router, PathGraphVersion } from './router';
 import { PrismaPoolAndHookWithDynamic } from '../../../prisma/prisma-types';
 import { checkInputs, isLiquidityManagement } from './utils/helpers';
 import {
@@ -38,6 +38,7 @@ export class SOR {
         bufferPools: BufferPoolData[],
         protocolVersion: number,
         swapOptions?: Omit<SorSwapOptions, 'graphTraversalConfig.poolIdsToInclude'>,
+        graphVersion: PathGraphVersion = 'original',
     ): Promise<PathWithAmount[] | null> {
         const checkedSwapAmount = checkInputs(tokenIn, tokenOut, swapKind, swapAmountEvm);
 
@@ -144,7 +145,7 @@ export class SOR {
             }
         }
 
-        const router = new Router();
+        const router = new Router(graphVersion);
 
         const candidatePaths = router.getCandidatePaths(
             tokenIn,

--- a/modules/sor/overview.md
+++ b/modules/sor/overview.md
@@ -1,0 +1,285 @@
+## Walkthrough
+
+Here’s a layered walkthrough of what this code is doing and how the main algorithms fit together, from pool ingestion all the way to picking final split routes.
+
+### High-level pipeline
+
+-   SOR.getPathsWithPools: Ingests pools from DB, normalizes them into in-memory pool models, and calls the Router.
+-   Router.getCandidatePaths: Builds a token–pool graph and searches for feasible token paths using bounded graph traversal + greedy edge-ranking.
+-   Router.getBestPaths: Quotes candidate paths at multiple size splits (25/50/75/100%), keeps only promising/non-overlapping ones, and picks the best split combination.
+-   Returns: A set of PathWithAmount objects that maximize output (GivenIn) or minimize input (GivenOut), possibly split across two paths.
+
+#### Layer 1 — Pool ingestion & normalization (SOR)
+
+-   Source: SOR.getPathsWithPools
+-   What it does:
+    -   Validates inputs and sets a “current time” (for pools with time-dependent state such as LBP or ReClamm).
+    -   Converts PrismaPool entries into in-memory BasePool subclasses (Weighted, Stable/Composable, Gyro, FX, Quant, ReClamm, v3 variants, etc.). Skips unsupported/misconfigured pools.
+    -   For protocol v3, also adds Buffer pools (used to connect fragmented liquidity segments).
+    -   Chooses a PathGraph implementation version (original/beam/bfs) and delegates to Router.
+-   Why: Separate I/O/domain data from routing logic. The rest of the system only sees BasePool interfaces with consistent methods (getNormalizedLiquidity, getLimitAmountSwap, swapGivenOut, etc.).
+
+#### Layer 2 — Graph building (PathGraph.buildGraph)
+
+-   Nodes: Tokens (by wrapped address). Phantom BPTs are also represented as token nodes if add/remove-liquidity paths are enabled.
+-   Edges: Directed edges from tokenIn → tokenOut labeled with:
+    -   pool (the BasePool connector)
+    -   tokenIn, tokenOut
+    -   normalizedLiquidity (used to rank edges per pair)
+    -   isBuffer (true for buffer pools)
+-   Edge curation (per token pair):
+    -   For each pair, sort candidate pool edges by normalizedLiquidity.
+    -   Keep only the top K (maxPathsPerTokenPair, default 10), except if either end is a phantom BPT—then include all to preserve boosted/add-liquidity routes.
+-   Why: This prunes the search space early and encodes “best connectors first,” which the traversal/expansion later exploits.
+
+#### Layer 3 — Token-path search (findAllValidTokenPaths)
+
+-   Method: traverseBfs (despite the name, it’s recursive depth-first over neighbors with BFS-like constraints).
+-   Constraints (PathGraphTraversalConfig, with sensible defaults):
+    -   maxDepth: cap on hops, default 6.
+    -   maxNonBoostedPathDepth: stricter cap if the path has no phantom BPT, default 3.
+    -   maxNonBoostedHopTokensInBoostedPath: limits how many non-boosted hops can be in a “boosted” path.
+    -   poolIdsToInclude: optional allowlist to restrict traversal.
+    -   maxBuffersInPath: limits the number of Buffer pools in a path (tighter on HyperEvm).
+-   Validity rules for token paths (before choosing the exact pool per hop):
+    -   No repeated token visits.
+    -   Respect the boosted/non-boosted depth rules above.
+-   Output: A set of token-address sequences [t0, t1, ..., tn] from tokenIn to tokenOut that satisfy the high-level constraints.
+-   Why: Separate “which tokens could we traverse through?” from “which specific pool edges should we pick for each token hop?”
+
+#### Layer 4 — Greedy edge selection per token path (expandTokenPathWithBestRanks)
+
+-   Goal: For a given token path [t0 → t1 → ... → tn], choose the best pool per hop (edge) quickly without exploring the full combinatorial space.
+-   Edge ranking: Each hop has a ranked list of candidate edges (rank 0 = highest normalizedLiquidity).
+-   Algorithm:
+    -   Start with ranks = [0, 0, ..., 0] (the highest-liquidity edge at every hop).
+    -   Expand combinations by incrementing ranks per segment (locally), but:
+        -   Early prune using a per-path capacity test: compute the path’s limit amount (see next bullet) and drop if it’s less than minLimitThreshold.
+        -   Lock segments once enough distinct ranks for that segment have produced acceptable paths or when ranks exceed available edges. This is tracked using finalRanks and maxRanksPerSegment (default 2).
+    -   Keep going until approxPathsToReturn (default 20) or the queue is exhausted.
+-   Path capacity test (getLimitAmountSwapForPath):
+    -   Compute the path’s maximum feasible swap size, accounting for pool-specific limits per hop.
+    -   Done backwards:
+        -   Start from the last hop’s limit for the requested swapKind (GivenIn or GivenOut).
+        -   For each preceding hop, pull back the limit either by using pool limits or by simulating swapGivenOut to determine how much input is needed to produce the downstream limit, then cap by pool’s GivenIn limit.
+-   minLimitThreshold: A quick heuristic bound to reduce noise:
+    -   minLimitThreshold = swapAmount \* minSwapAmountRatio (default ~50%)
+    -   Paths must be able to handle at least that fraction of the request to be considered during greedy expansion.
+-   Why: Liquidity-ranked greedy selection plus capacity pruning finds strong candidates fast without full-blown exponential exploration.
+
+#### Layer 5 — Path validity and final filtering (sortAndFilterPaths, isValidPath)
+
+-   Validate:
+    -   No pool is used twice inside a path.
+    -   Not already selected (by a composite path ID built from pool+tokenIn+tokenOut).
+    -   Respect maxBuffersInPath from config.
+    -   If poolIdsToInclude is set, ensure every hop uses an allowed pool.
+-   Rank/sort:
+    -   Compute each path’s limit (GivenIn) and sort descending by that limit.
+    -   Deduplicate by ID and keep uniqueness again.
+-   Output: PathLocal objects, which carry the token sequence, the chosen pools per hop, and buffer flags per hop.
+-   Why: Ensure uniqueness, feasibility, and prioritize the most “capable” paths.
+
+#### Layer 6 — Quoting and split-route selection (Router.getBestPaths)
+
+-   Input: Candidate PathLocal[]; the final swapAmount and swapKind.
+-   Split strategy:
+    -   Consider 4 sizes: 25%, 50%, 75%, 100% of the requested amount.
+    -   For each size and each path:
+        -   Build a PathWithAmount (which quotes amounts using pool math).
+        -   Filter out zero-amount results (common at tiny sizes) and paths that are too gas-expensive on HyperEvm if they include too many buffer steps.
+    -   Sort each bucket (25/50/75/100) by best quote:
+        -   GivenIn: descending by outputAmount.
+        -   GivenOut: ascending by inputAmount.
+-   Construct split candidates:
+    -   100% on the best 100% path.
+    -   75/25 split: try best 75% path + a 25% path that shares no pool with it.
+    -   50/50 split: try best 50% path + the best disjoint 50% path.
+    -   Copy pools and enable mutateBalances so that using the same pool across split legs is safe in simulation.
+-   Choose the winner:
+    -   GivenIn: maximize sum of outputs.
+    -   GivenOut: minimize sum of inputs.
+-   Output: The best one- or two-path combination (PathWithAmount[]), or null if nothing valid.
+-   Why: Small set of split heuristics captures most gains from routing across independent liquidity sources without heavy combinatorics.
+
+_Important knobs and heuristics_
+
+-   Graph pruning: maxPathsPerTokenPair (top-K edges by normalizedLiquidity) and boosted (phantom BPT) exceptions to keep important structural routes.
+-   Traversal constraints: maxDepth, boosted/non-boosted depth rules, maxBuffersInPath (tighter on HyperEvm).
+-   Greedy edge expansion: approxPathsToReturn, maxRanksPerSegment, minSwapAmountRatio for early-capacity pruning.
+-   Split routing: limited to 100, 75/25, 50/50 with disjoint-pool preference to avoid self-competition and to improve capacity.
+
+_Correctness and complexity notes_
+
+-   Token-path search is bounded depth-first traversal with domain-specific constraints that prevent cycles and overlong paths.
+-   Pool selection per hop is a greedy best-first scheme over ranked edges with early capacity filtering; it doesn’t enumerate all combinations (by design).
+-   Path capacity is computed exactly via backward propagation with pool-specific limits and swap simulations (swapGivenOut).
+-   Split-route selection explores only a few combinations but covers the common sweet spots for multi-path improvements.
+-   Naming note: traverseBfs is recursive and behaves more like depth-first enumeration over neighbors (it’s bounded/filtered, so the practical difference is small here).
+
+### Layer responsibilities summary
+
+-   SOR (integration/orchestration):
+    -   Transforms DB pools into in-memory BasePool instances.
+    -   Adds v3 Buffer pools.
+    -   Wires up router, returns best split paths.
+-   Router (coordination + path scoring/splitting):
+    -   Builds the graph via PathGraph.
+    -   Gets candidate paths.
+    -   Quotes and selects best split combination.
+-   PathGraph (graph + search):
+    -   Nodes/edges creation with ranked edges per token pair.
+    -   Token-path enumeration with depth/boosted constraints.
+    -   Greedy edge selection per token path with capacity checks.
+    -   Path validation, de-dup, and limit-based sorting.
+-   BasePool family (math/quoting primitives):
+    -   Expose normalizedLiquidity for ranking.
+    -   Provide getLimitAmountSwap, swapGivenOut, etc., to compute per-hop and path capacities and quotes.
+
+If you want, I can draw a quick call graph or walk through a concrete example (e.g., 3-hop path with two ranks per segment) to illustrate the rank queue and limit propagation.
+
+## Review
+
+Here’s a blunt review, then a prioritized set of optimizations with tradeoffs, plus how this compares to state-of-the-art DEX routing.
+
+### What’s solid
+
+-   Clear layering and clean separation of concerns (pool ingestion → graph → candidate pathing → quoting/split selection).
+-   Aggressive but sensible pruning (top-K by normalizedLiquidity, bounded depth, boosted path constraints, max buffers).
+-   Capacity-aware pruning during edge selection (minLimitThreshold) prevents wasting time on tiny-capacity routes.
+-   Backwards limit propagation per path is correct in spirit and avoids overestimating path capacity.
+-   Disjoint split preference in 75/25 and 50/50 is good.
+
+### issues and pitfalls
+
+Correctness/suboptimality
+
+-   Split routing is extremely coarse. Only 100%, 75/25, and 50/50 are tried, and only one disjoint candidate per split is considered. This will routinely miss large improvements. State-of-the-art does continuous allocation across more than two paths.
+-   Silent path filtering across ratios is likely wrong:
+    -   In getBestPaths you do validPaths = selectedPaths after each ratio. This throws away paths that might be bad at 25% (rounding-to-zero) but great at 100%. You’re biasing later ratios toward “survived” paths rather than “best” paths.
+-   The “greedy ranks” expander can finalize the wrong segment:
+    -   In expandTokenPathWithBestRanks, currentFinalRankIndex = finalRanks.length assumes segments are finalized left→right. Errors thrown in expandTokenPathWithRanks (missing rank) could originate from any segment, but you finalize the “next” segment regardless. That can prematurely prune good combinations.
+-   Hard caps (maxBuffersInPath) are blunt. Gas impact should be modeled in the objective, not only as a strict cutoff (except where chain limits force it). You can mistakenly exclude profitable-but-buffer-heavy paths with low gas.
+-   traverseBfs is actually DFS-with-constraints. That’s fine, but the name is misleading and it doesn’t prioritize promising neighbors first. You could be exploring mediocre branches before clearly better ones.
+
+### Performance/engineering
+
+-   Re-sorting edges on every addEdge insert (TODO note present). With large graphs this is a hotspot. Keep a fixed-size min-heap or do binary insertion and cap to K to avoid full re-sorts.
+-   Limit computation duplication:
+    -   getLimitAmountSwapForPath is called in the greedy phase and again in sortAndFilterPaths. There’s no memoization keyed by pathId+swapKind. This is an easy win.
+-   addAlternativeRanks uses global maxPathsPerTokenPair to decide whether to add next rank for a segment. That can push out-of-range ranks for segments with fewer edges, generate errors, and then rely on catch to prune. Check per-segment max ranks up front.
+-   getConnectedVertices fallback uses [] but the loop expects a Map iterator. It works only because addNode initializes edges for all tokens, but the fallback is type-inconsistent and one missed init becomes a subtle runtime bug.
+-   selectedPathIds duplication check is repeated in both getCandidatePaths and sortAndFilterPaths; do it once with consistent ordering.
+-   isValidPath’s seenPoolAddresses is always an empty array at call sites; it never affects selection. If you don’t intend to do global pool de-dup across selected paths, remove it or actually maintain it across chosen paths per tokenPath to encourage diversity.
+-   Building BPT tokens ad hoc (decimals hardcoded to 18) may be wrong for some variants.
+
+### Algorithmic and modeling gaps
+
+-   Ranking edges purely by normalizedLiquidity is a weak proxy. It ignores price, fee structures, and current reserves’ marginal price. For many AMMs, “higher normalized liquidity” != “better output for this size.”
+-   Phantom/BPT exception “include unlimited edges” can explode branching on some topologies.
+-   No gas-aware scoring except a HyperEvm hard limit. For L1 or gas-heavy chains, you need gas in the objective to avoid long fragile routes.
+-   No global route diversity mechanism beyond “disjoint for splits.” Candidate generation may return many near-duplicates.
+
+## What I’d change: optimizations by effort level
+
+### Quick wins (low risk, high ROI)
+
+-   Fix split filtering bug:
+    -   Don’t set validPaths = selectedPaths between split ratios. Compute 25/50/75/100 on the full candidate set. If you need to cap runtime, limit per-ratio to top M candidates rather than shrinking the universe across ratios.
+-   Memoize path limits and quotes:
+    -   Cache getLimitAmountSwapForPath(pathId, swapKind) and simple path quotes for recurring (path, amount) pairs or a small set of sample points per path. You call limits multiple times (greedy + sorting).
+-   Edge insertion perf:
+    -   Maintain a fixed-size top-K structure per token pair:
+        -   If size < K: insert (binary insert or push+single pass).
+        -   Else if newEdge.liq <= smallest.liq: drop.
+        -   Else insert and drop smallest.
+    -   Avoid full sort per insertion.
+-   Correct rank exploration bounds:
+    -   Precompute segmentsMaxRanks[i] = edges(token[i], token[i+1]).length.
+    -   In addAlternativeRanks, only push new ranks if currentRank + 1 < segmentsMaxRanks[i].
+    -   Remove the try/catch-as-control-flow for “missing rank.”
+-   Improve greedy rank exploration:
+    -   Switch to a proper beam search per tokenPath:
+        -   Define a score: e.g., clamp(limit) or a fast sample quote at the target amount (or at min(amount, pathLimit)).
+        -   Keep a priority queue of rank vectors ordered by score, expand by bumping one segment’s rank at a time, keep top B candidates (beam width).
+        -   Enforce maxRanksPerSegment by counting distinct ranks per segment among kept candidates.
+    -   This gives better coverage and removes the “finalRanks guessing” bug.
+-   Use gas-aware path scoring:
+    -   Estimate gas per hop by pool type, compute netOut = amountOut - gasCostInTokenOut (via price oracle or current mid-price). Use netOut as sorting metric for selection and split decisions.
+
+### Medium effort (structural improvements)
+
+-   Better path split optimization (continuous rather than fixed 25/50/75/100):
+    -   Waterfilling/Lagrange multiplier method over a small set of top paths (N=3–6):
+        -   For each path, define f_i(x) = output for input x (monotone, diminishing returns in most CFMMs).
+        -   Allocate x_i to equalize marginal returns f_i’(x_i) subject to sum x_i = X and 0 ≤ x_i ≤ limit_i.
+        -   Numerically approximate f_i’ with finite diffs and solve via binary search on a shared λ (or do iterative greedy in small chunks).
+        -   This is how Balancer SOR v2-class and several aggregators approximate optimal splitting.
+    -   Tradeoff: a few more quotes per iteration but it’s still cheap with N small; outcome is significantly closer to optimal.
+-   Candidate path diversity and dedup:
+    -   When collecting candidates, prefer pool-disjoint or minimally-overlapping paths and drop dominated ones (strictly lower limit and worse estimated output).
+-   Gas as a soft constraint:
+    -   Replace hard maxBuffersInPath (except HyperEvm hard rule) with a penalty in the score, e.g., score = amountOut - alpha \* gasInOutToken. Choose alpha from on-chain gas and token price.
+
+### High effort (approaching state-of-the-art)
+
+-   Path-based piecewise-linear modeling + LP:
+    -   For each selected path, sample (x, f_i(x)) at 4–8 points to build a concave PWL approximation. Solve a small LP to maximize sum f_i(x_i) with sum x_i = X and x_i within knots. This finds near-optimal splits over many paths cleanly and quickly.
+    -   Tradeoff: Slight complexity to build PWL and solve LP (but with N ≤ 6 it’s trivial).
+-   Multi-source graph search with better heuristics:
+    -   Use A\* or best-first search over tokens prioritizing neighbors with higher aggregate liquidity and better indicative spot price to the target token. This finds shorter, better paths earlier and reduces combinatorics.
+    -   Consider k-shortest simple paths (Yen/Eppstein) over a cost metric like -log(normalizedLiquidity) + hop penalty, then refine each with pool-level selection.
+-   Global gas-awareness:
+    -   Calibrate per-pool-type gas constants empirically and include them consistently in both candidate selection and final optimization.
+
+### Comparing to state-of-the-art
+
+-   1inch Pathfinder / ParaSwap / 0x:
+    -   They explore many more sources, build richer candidate sets, and then solve for continuous splits (or a very fine discrete approximation). They account for gas in the objective and often use beam/best-first techniques with heuristics tied to marginal price and liquidity.
+    -   Your approach is fast and predictable but much coarser: fixed-ratio splits, limited rank exploration, and liquidity-only ranking. You’ll leave meaningful edge on the table on complex pairs or larger sizes.
+-   Balancer SOR v2-like methods:
+    -   Historically used continuous split optimization across a small set of candidate paths (waterfilling/Lagrange), and included gas costs in the objective. Your code improves on search pruning for v3/phantom routes, but the split step regressed in optimality due to the coarse 25/50/75/100 scheme.
+
+### Concrete fixes (actionable)
+
+-   Bug/logic
+    -   Don’t shrink validPaths across ratios. Compute all four ratios over the full candidate set.
+    -   Fix rank-finalization logic. Replace try/catch with explicit bounds and move to a beam search prioritized by a real score.
+    -   Tighten addAlternativeRanks to respect per-segment edge counts.
+    -   Memoize getLimitAmountSwapForPath by pathId+swapKind.
+-   Performance
+    -   Replace per-insert sort with top-K maintenance (heap or bounded ordered array).
+    -   Cache normalizedLiquidity results per (pool, tokenIn, tokenOut) while building edges.
+-   Quality
+    -   Add gas-aware scoring and selection. Apply as a penalty rather than just a hard cap (except where necessary on HyperEvm).
+    -   Consider adding a quick two-path continuous splitter (waterfilling) as a drop-in replacement for the 75/25 and 50/50 discrete tests. Then generalize to 3–4 paths.
+    -   Prefer diversity: when expanding per tokenPath, deprioritize edges that reuse pools from already-selected good candidates unless they bring a clearly higher score.
+
+### Sketches
+
+-   Beam search on ranks (per token path)
+    -   Keep priority queue of rank vectors scored by min(limit, quoteAtTarget) - gasPenalty.
+    -   Pop best, expand by incrementing one segment’s rank (within available edges).
+    -   Stop at beam width B or cap of candidates.
+-   Continuous split (two-path quick version)
+    -   Binary search over x in [0, X] maximizing f1(x) + f2(X-x) - gasPenalty. Generalize to N paths via Lagrange waterfilling or small PWL+LP.
+
+### Tradeoffs
+
+-   More accurate splitting (waterfilling/PWL+LP) vs. latency: adds a handful of extra quotes per candidate path. With N ≤ 6 it’s negligible relative to network/db overhead and pays back in better execution.
+-   Beam/best-first vs. current greedy ranks: slightly more bookkeeping, but avoids the segment-finalization pitfalls and gets better candidates for roughly the same bound (approxPathsToReturn).
+-   Gas-aware objective vs. hard constraints: better real-world outcomes but requires maintaining gas estimates and token price conversions.
+
+### Prioritized roadmap
+
+1. Fix split filtering and add memoization + top-K edge maintenance. Easy wins.
+2. Replace greedy ranks with a beam search scored by limit-adjusted quote; enforce per-segment rank bounds explicitly.
+3. Add gas-aware scoring and remove maxBuffersInPath except where chain-specific constraints force it.
+4. Implement two-path continuous splitter; then extend to 3–4 paths or PWL+LP for N paths.
+5. Consider A\*/k-shortest for token-path discovery if you need more throughput or quality on very large graphs.
+
+If you want, I can:
+
+-   Draft a beam-search drop-in for expandTokenPathWithBestRanks.
+-   Implement a two-path waterfilling splitter to replace 75/25 + 50/50.
+-   Add a small memoization layer around getLimitAmountSwapForPath and PathWithAmount quotes.

--- a/modules/sor/sor.service.ts
+++ b/modules/sor/sor.service.ts
@@ -153,12 +153,12 @@ export class SorService {
         }
     }
 
-    private buildSwapOptions(maxNonBoostedPathDepth: number): {
+    private buildSwapOptions(maxDepth: number): {
         graphTraversalConfig: GraphTraversalConfig;
     } {
         return {
             graphTraversalConfig: {
-                maxNonBoostedPathDepth,
+                maxDepth,
             },
         };
     }

--- a/modules/sor/sor.service.ts
+++ b/modules/sor/sor.service.ts
@@ -16,10 +16,13 @@ import {
 } from './utils';
 import { PathWithAmount } from './lib/path';
 import { getInputAmount, getOutputAmount } from './lib/utils';
+import { PathGraphVersion } from './lib/router';
 
 const DEFAULT_MAX_DEPTH = 4;
 
 export class SorService {
+    constructor(private pathGraphVersion: PathGraphVersion = 'original') {}
+
     async getSorSwapPaths(args: QuerySorGetSwapPathsArgs): Promise<GqlSorGetSwapPaths> {
         console.log('getSorSwaps args', JSON.stringify(args));
         const tokenIn = args.tokenIn.toLowerCase();
@@ -106,6 +109,7 @@ export class SorService {
                 bufferPools,
                 input.protocolVersion,
                 swapOptions,
+                this.pathGraphVersion,
             );
 
             if (!paths) {
@@ -119,6 +123,7 @@ export class SorService {
                     bufferPools,
                     input.protocolVersion,
                     swapOptions,
+                    this.pathGraphVersion,
                 );
             }
 

--- a/modules/sor/sor.service.ts
+++ b/modules/sor/sor.service.ts
@@ -7,6 +7,7 @@ import { SOR } from './lib/sor';
 import {
     getBasePoolsFromDb,
     getToken,
+    getTokenPricesMap,
     isValidSwapRequest,
     mapSwapKind,
     mapToGetSwapPathsInput,
@@ -40,12 +41,15 @@ export class SorService {
         const getSwapPathsInput = await mapToGetSwapPathsInput({ ...args, tokenIn, tokenOut });
 
         // get swap paths from sor for the requested protocol version mapped as sor service output type
+        const sorStart = performance.now();
         const { paths, protocolVersion } = args.useProtocolVersion
             ? await this.getSwapPathsWithRetry({
                   ...getSwapPathsInput,
                   protocolVersion: args.useProtocolVersion,
               })
             : await this.getBestSwapPathFromBothVersions(getSwapPathsInput);
+        const sorEnd = performance.now();
+        console.log(`SOR:getSwapPaths: ${(sorEnd - sorStart).toFixed(2)}ms`);
 
         // return zero response if no paths are found
         if (!paths) {
@@ -94,6 +98,9 @@ export class SorService {
                 input.poolIds,
             );
 
+            // used for early pruning of paths based on swap limits
+            const tokenPrices = await getTokenPricesMap(input.chain);
+
             const tokenIn = await getToken(input.tokenIn as Address, input.chain);
             const tokenOut = await getToken(input.tokenOut as Address, input.chain);
             const swapKind = mapSwapKind(input.swapType);
@@ -108,6 +115,7 @@ export class SorService {
                 poolsFromDb,
                 bufferPools,
                 input.protocolVersion,
+                tokenPrices,
                 swapOptions,
                 this.pathGraphVersion,
             );
@@ -122,6 +130,7 @@ export class SorService {
                     poolsFromDb,
                     bufferPools,
                     input.protocolVersion,
+                    tokenPrices,
                     swapOptions,
                     this.pathGraphVersion,
                 );

--- a/modules/sor/utils/data.ts
+++ b/modules/sor/utils/data.ts
@@ -33,17 +33,16 @@ export async function getBasePoolsFromDb(
     considerPoolsWithHooks: boolean,
     poolIds?: string[],
 ): Promise<{ pools: SORDbPool[]; bufferPools: BufferPoolData[] }> {
+    console.time('SOR:getpools');
     const cacheKey = `${SOR_POOLS_CACHE_KEY}:${chain}:${poolIds}`;
 
     let cached = cache.get(cacheKey);
 
     if (!cached) {
         // get pools
-        console.time('SOR:getpools');
         const pools = await getPools(chain, poolIds);
-        console.timeEnd('SOR:getpools');
         const bufferPools = await getBufferPoolsFromDBPools(pools, chain);
-        cached = cache.put(cacheKey, { pools, bufferPools }, parseInt(env.SOR_POOLS_CACHE_TTL_SECONDS) * 1000);
+        cached = cache.put(cacheKey, { pools, bufferPools }, 60 * 1000);
     }
 
     // Filter
@@ -66,6 +65,8 @@ export async function getBasePoolsFromDb(
     const requestedPoolIds = pools.map((pool) => pool.id);
 
     const bufferPools = cached.bufferPools.filter((bufferPool) => requestedPoolIds.includes(bufferPool.poolId));
+
+    console.timeEnd('SOR:getpools');
 
     return { pools, bufferPools };
 }
@@ -283,4 +284,17 @@ function logMissingTokens(underlyingTokens: PrismaToken[], underlyingTokenAddres
             }
         });
     }
+}
+
+/**
+ * Fetches current token prices for a chain and returns a lowercase-address -> price map.
+ * Uses the shared tokenService cache to avoid redundant DB hits.
+ */
+export async function getTokenPricesMap(chain: Chain): Promise<Map<string, number>> {
+    const prices = await tokenService.getTokenPrices(chain);
+    const map = new Map<string, number>();
+    for (const p of prices) {
+        map.set(p.tokenAddress.toLowerCase(), p.price);
+    }
+    return map;
 }

--- a/modules/token/token.service.ts
+++ b/modules/token/token.service.ts
@@ -133,14 +133,11 @@ export class TokenService {
                     },
                 })
                 .then((types) =>
-                    types.reduce(
-                        (agg, item) => {
-                            agg[`${item.chain}-${item.tokenAddress}`] ||= [];
-                            agg[`${item.chain}-${item.tokenAddress}`].push(item.type);
-                            return agg;
-                        },
-                        {} as Record<string, PrismaTokenTypeOption[]>,
-                    ),
+                    types.reduce((agg, item) => {
+                        agg[`${item.chain}-${item.tokenAddress}`] ||= [];
+                        agg[`${item.chain}-${item.tokenAddress}`].push(item.type);
+                        return agg;
+                    }, {} as Record<string, PrismaTokenTypeOption[]>),
                 ),
         ]);
 
@@ -315,7 +312,7 @@ export class TokenService {
         let tokenPrices = this.cache.get(`${TOKEN_PRICES_CACHE_KEY}:${chain}`);
         if (!tokenPrices) {
             tokenPrices = await this.tokenPriceService.getCurrentTokenPrices([chain]);
-            this.cache.put(`${TOKEN_PRICES_CACHE_KEY}:${chain}`, tokenPrices, 30 * 1000);
+            this.cache.put(`${TOKEN_PRICES_CACHE_KEY}:${chain}`, tokenPrices, 60 * 1000);
         }
         return tokenPrices;
     }

--- a/scripts/profile-sor.ts
+++ b/scripts/profile-sor.ts
@@ -534,15 +534,19 @@ class SorProfiler {
             const deltasPct: number[] = [];
             let better = 0,
                 worse = 0,
-                same = 0;
+                same = 0,
+                zero = 0;
             for (let i = 0; i < baseline.length; i++) {
                 const base = baseline[i] || 0;
                 const val = data.amounts[i] || 0;
                 const delta = val - base;
                 const pct = base !== 0 ? (delta / base) * 100 : 0;
                 deltas.push(delta);
-                if (Math.abs(delta) < 1e-12) same++;
-                else {
+                if (base === 0 && val === 0) {
+                    zero++;
+                } else if (Math.abs(delta) < 1e-12) {
+                    same++;
+                } else {
                     deltasPct.push(pct);
                     if (delta > 0) better++;
                     else worse++;
@@ -551,28 +555,28 @@ class SorProfiler {
             const avgPct = deltasPct.reduce((s, v) => s + v, 0) / deltasPct.length;
             console.log(`   ${algo}:`);
             console.log(`      Avg delta % vs baseline: ${avgPct.toFixed(4)}%`);
-            console.log(`      Better: ${better}, Worse: ${worse}, Same: ${same}`);
+            console.log(`      Better: ${better}, Worse: ${worse}, Same: ${same}, Zero: ${zero}`);
 
-            // Detailed logs for worse cases to understand path differences
-            const maxLogs = 10;
-            let logged = 0;
-            for (let i = 0; i < baseline.length && logged < maxLogs; i++) {
-                const baseVal = baseline[i] || 0;
-                const curVal = data.amounts[i] || 0;
-                if (curVal <= baseVal && Math.abs(curVal - baseVal) > 1e-12) {
-                    const swap = swaps[i];
-                    const baseRes = results[baselineAlgo].results[i];
-                    const curRes = data.results[i];
-                    console.log(`\n   🔎 Swap #${i + 1}: ${swap.tokenIn} -> ${swap.tokenOut} amount=${swap.amount}`);
-                    console.log(
-                        `      Baseline(${baselineAlgo}) return=${baseRes.returnAmount}, paths=${baseRes.paths.length}`,
-                    );
-                    this.printPaths(baseRes.paths);
-                    console.log(`      ${algo} return=${curRes.returnAmount}, paths=${curRes.paths.length}`);
-                    this.printPaths(curRes.paths);
-                    logged++;
-                }
-            }
+            // // Detailed logs for worse cases to understand path differences
+            // const maxLogs = 10;
+            // let logged = 0;
+            // for (let i = 0; i < baseline.length && logged < maxLogs; i++) {
+            //     const baseVal = baseline[i] || 0;
+            //     const curVal = data.amounts[i] || 0;
+            //     if (curVal <= baseVal && Math.abs(curVal - baseVal) > 1e-12) {
+            //         const swap = swaps[i];
+            //         const baseRes = results[baselineAlgo].results[i];
+            //         const curRes = data.results[i];
+            //         console.log(`\n   🔎 Swap #${i + 1}: ${swap.tokenIn} -> ${swap.tokenOut} amount=${swap.amount}`);
+            //         console.log(
+            //             `      Baseline(${baselineAlgo}) return=${baseRes.returnAmount}, paths=${baseRes.paths.length}`,
+            //         );
+            //         this.printPaths(baseRes.paths);
+            //         console.log(`      ${algo} return=${curRes.returnAmount}, paths=${curRes.paths.length}`);
+            //         this.printPaths(curRes.paths);
+            //         logged++;
+            //     }
+            // }
         }
     }
 

--- a/scripts/profile-sor.ts
+++ b/scripts/profile-sor.ts
@@ -1,539 +1,663 @@
 #!/usr/bin/env node
 
 /**
- * Original SOR CPU Profiling Script
+ * SOR CPU Profiling Script
  *
- * Isolated profiling for the original SOR implementation only
- * Generates CPU profiles compatible with Chrome DevTools
+ * Usage:
+ *   npx tsx scripts/profile-sor.ts [options]
  *
- * Run with: node --loader tsx scripts/profile-sor.ts
+ * Options:
+ *   --fetch <count>              Fetch and save swap data only
+ *   --file <path>                Use swaps from file
+ *   --swap <tokenIn,tokenOut,amount>  Test single swap
+ *   --count <n>                  Number of swaps to fetch (default: 100)
+ *   --help                       Show help
  */
 
-import { performance, PerformanceObserver } from 'perf_hooks';
-import * as v8 from 'v8';
+import { performance } from 'perf_hooks';
 import * as fs from 'fs';
 import * as path from 'path';
 import { Session } from 'inspector';
 import { promisify } from 'util';
 import { SorService } from '../modules/sor/sor.service';
-import { QuerySorGetSwapPathsArgs } from '../apps/api/gql/generated-schema';
+import mainnetConfig from '../config/mainnet';
+import { getViemClient } from '../modules/sources/viem-client';
+import { multicallViem } from '../modules/web3/multicaller-viem';
+import { parseAbiItem } from 'abitype';
+import { formatUnits, getAddress, keccak256, toHex, encodeAbiParameters, parseAbiParameters } from 'viem';
 
-interface SwapConfig {
-    name: string;
+// Configuration
+const CONFIG = {
+    vaults: {
+        v2: mainnetConfig.balancer.v2.vaultAddress,
+        v3: mainnetConfig.balancer.v3.vaultAddress,
+    },
+    eventSignatures: {
+        v2: '0x2170c741c41531aec20e7c107c24eecfdd15e69c9bb0a8dd37b1840b9e0b207b',
+        v3: '0x' + keccak256(toHex('Swap(address,address,address,uint256,uint256,uint256,uint256)')).slice(2),
+    },
+    defaults: {
+        swapCount: 100,
+        blocksToSearch: 7200,
+        dataDir: path.join(process.cwd(), 'profiles', 'real-swaps'),
+        defaultSwapsFile: 'latest-swaps.json',
+    },
+};
+
+// Types
+interface SwapData {
     tokenIn: string;
     tokenOut: string;
-    swapAmount: string;
-    swapType: 'EXACT_IN' | 'EXACT_OUT';
-    chain: string;
+    amount: string; // This is amountIn scaled (for backward compatibility)
+    amountIn: string; // Raw amount in
+    amountOut: string; // Raw amount out  
+    amountInScaled?: string; // Scaled amount in
+    amountOutScaled?: string; // Scaled amount out
+    poolId?: string;
+    blockNumber?: number;
+    transactionHash?: string;
+    protocolVersion?: '2' | '3';
 }
 
-interface FunctionProfile {
-    functionName: string;
-    file: string;
-    line: number;
-    selfTime: number;
-    totalTime: number;
-    callCount: number;
-    percentOfTotal: number;
+interface SwapComparison {
+    swap: SwapData;
+    sorReturnAmount: string;
+    actualAmountOut: string;
+    deviation: number;
+    deviationPercent: number;
 }
 
-interface CPUProfile {
-    topFunctions: FunctionProfile[];
-    totalTime: number;
-    profileData?: any;
+interface ProfileResult {
+    successful: number;
+    failed: number;
+    duration: number;
+    avgPerSwap: number;
+    topFunctions?: any[];
+    comparisons?: SwapComparison[];
+    biggestDeviations?: SwapComparison[];
 }
 
-class OriginalSorProfiler {
-    private session: Session | null = null;
-    private originalSor = new SorService();
-    private profilesDir = path.join(process.cwd(), 'profiles', 'original-sor');
+// Utilities
+function ensureDirectory(dir: string): void {
+    if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+    }
+}
 
-    constructor() {
-        // Create profiles directory if it doesn't exist
-        if (!fs.existsSync(this.profilesDir)) {
-            fs.mkdirSync(this.profilesDir, { recursive: true });
+function formatTimestamp(): string {
+    return new Date().toISOString().replace(/:/g, '-').split('.')[0];
+}
+
+function getSwapsFilePath(filename?: string): string {
+    ensureDirectory(CONFIG.defaults.dataDir);
+    return path.join(CONFIG.defaults.dataDir, filename || CONFIG.defaults.defaultSwapsFile);
+}
+
+// 1. Swap Data Fetcher - Fetches and stores swap data
+class SwapDataFetcher {
+    private viemClient = getViemClient('MAINNET');
+    private tokenDecimals = new Map<string, number>();
+
+    async fetchAndSaveSwaps(count: number = CONFIG.defaults.swapCount, outputFile?: string): Promise<string> {
+        console.log(`\n🔍 Fetching ${count} recent swaps from Balancer...`);
+
+        const swaps = await this.fetchRecentSwaps(count);
+        const filePath = getSwapsFilePath(outputFile);
+
+        fs.writeFileSync(filePath, JSON.stringify(swaps, null, 2));
+        console.log(`✅ Saved ${swaps.length} swaps to: ${filePath}`);
+
+        return filePath;
+    }
+
+    private async fetchRecentSwaps(count: number): Promise<SwapData[]> {
+        const currentBlock = Number(await this.viemClient.getBlockNumber());
+        const fromBlock = currentBlock - CONFIG.defaults.blocksToSearch;
+
+        // Fetch logs
+        const [v2Logs, v3Logs] = await Promise.all([
+            this.fetchLogs(CONFIG.vaults.v2, CONFIG.eventSignatures.v2, fromBlock, currentBlock),
+            this.fetchLogs(CONFIG.vaults.v3, CONFIG.eventSignatures.v3, fromBlock, currentBlock),
+        ]);
+
+        console.log(`   Found: ${v2Logs.length} v2, ${v3Logs.length} v3 swaps`);
+
+        // Parse swaps
+        const v2Swaps = this.parseV2Swaps(v2Logs);
+        const v3Swaps = this.parseV3Swaps(v3Logs);
+
+        // Select balanced set
+        const selected = this.selectBalancedSwaps(v2Swaps, v3Swaps, count);
+
+        // Fetch decimals and scale amounts
+        await this.fetchTokenDecimals(selected);
+
+        console.log(`   Selected: ${selected.length} unique swaps`);
+        return selected;
+    }
+
+    private async fetchLogs(address: string, topic: string, fromBlock: number, toBlock: number): Promise<any[]> {
+        const logs = (await this.viemClient.request({
+            method: 'eth_getLogs',
+            params: [
+                {
+                    address: address as `0x${string}`,
+                    topics: [topic as `0x${string}`],
+                    fromBlock: toHex(fromBlock),
+                    toBlock: toHex(toBlock),
+                },
+            ],
+        })) as any[];
+
+        return logs;
+    }
+
+    private parseV2Swaps(logs: any[]): SwapData[] {
+        return logs
+            .map((log) => {
+                try {
+                    const data = (log.data as string).slice(2);
+                    const amountIn = BigInt('0x' + data.slice(0, 64)).toString();
+                    const amountOut = BigInt('0x' + data.slice(64, 128)).toString();
+                    return {
+                        tokenIn: getAddress('0x' + (log.topics[2] as string).slice(26)).toLowerCase(),
+                        tokenOut: getAddress('0x' + (log.topics[3] as string).slice(26)).toLowerCase(),
+                        amount: amountIn, // Keep for backward compatibility
+                        amountIn,
+                        amountOut,
+                        poolId: log.topics[1] as string,
+                        blockNumber:
+                            typeof log.blockNumber === 'string'
+                                ? parseInt(log.blockNumber, 16)
+                                : Number(log.blockNumber),
+                        transactionHash: log.transactionHash as string,
+                        protocolVersion: '2' as const,
+                    };
+                } catch {
+                    return null;
+                }
+            })
+            .filter(Boolean) as SwapData[];
+    }
+
+    private parseV3Swaps(logs: any[]): SwapData[] {
+        return logs
+            .map((log) => {
+                try {
+                    const data = (log.data as string).slice(2);
+                    const amountIn = BigInt('0x' + data.slice(0, 64)).toString();
+                    const amountOut = BigInt('0x' + data.slice(64, 128)).toString();
+                    // Note: V3 also has swapFeePercentage at data.slice(128, 192) and swapFeeAmount at data.slice(192, 256)
+                    return {
+                        tokenIn: getAddress('0x' + (log.topics[2] as string).slice(26)).toLowerCase(),
+                        tokenOut: getAddress('0x' + (log.topics[3] as string).slice(26)).toLowerCase(),
+                        amount: amountIn, // Keep for backward compatibility
+                        amountIn,
+                        amountOut,
+                        poolId: '0x' + (log.topics[1] as string).slice(26),
+                        blockNumber:
+                            typeof log.blockNumber === 'string'
+                                ? parseInt(log.blockNumber, 16)
+                                : Number(log.blockNumber),
+                        transactionHash: log.transactionHash as string,
+                        protocolVersion: '3' as const,
+                    };
+                } catch {
+                    return null;
+                }
+            })
+            .filter(Boolean) as SwapData[];
+    }
+
+    private selectBalancedSwaps(v2Swaps: SwapData[], v3Swaps: SwapData[], count: number): SwapData[] {
+        const selected: SwapData[] = [];
+        const seenPairs = new Set<string>();
+
+        // Sort by newest
+        v2Swaps.sort((a, b) => (b.blockNumber || 0) - (a.blockNumber || 0));
+        v3Swaps.sort((a, b) => (b.blockNumber || 0) - (a.blockNumber || 0));
+
+        // Select unique pairs
+        for (const swaps of [v2Swaps, v3Swaps]) {
+            for (const swap of swaps) {
+                if (selected.length >= count) break;
+
+                const pairKey = `${swap.tokenIn}-${swap.tokenOut}`;
+                if (!seenPairs.has(pairKey)) {
+                    seenPairs.add(pairKey);
+                    selected.push(swap);
+                }
+            }
+        }
+
+        return selected;
+    }
+
+    private async fetchTokenDecimals(swaps: SwapData[]): Promise<void> {
+        const uniqueTokens = Array.from(new Set(swaps.flatMap((s) => [s.tokenIn, s.tokenOut])));
+
+        const calls = uniqueTokens.map((token) => ({
+            path: token,
+            address: token as `0x${string}`,
+            abi: [parseAbiItem('function decimals() view returns(uint8)')],
+            functionName: 'decimals',
+        }));
+
+        try {
+            const results = await multicallViem(this.viemClient, calls);
+            for (const token of uniqueTokens) {
+                this.tokenDecimals.set(token, Number(results[token] || 18));
+            }
+        } catch {
+            uniqueTokens.forEach((token) => this.tokenDecimals.set(token, 18));
+        }
+
+        // Convert amounts to human-readable format
+        for (const swap of swaps) {
+            const inDecimals = this.tokenDecimals.get(swap.tokenIn) || 18;
+            const outDecimals = this.tokenDecimals.get(swap.tokenOut) || 18;
+            
+            // Scale both amounts
+            swap.amountInScaled = formatUnits(BigInt(swap.amountIn), inDecimals);
+            swap.amountOutScaled = formatUnits(BigInt(swap.amountOut), outDecimals);
+            
+            // Keep 'amount' as scaled amountIn for backward compatibility
+            swap.amount = swap.amountInScaled;
         }
     }
+}
 
-    private async startCPUProfiling(): Promise<void> {
-        this.session = new Session();
-        this.session.connect();
+// 2. SOR Profiler - Tests SOR with provided swaps
+class SorProfiler {
+    async profileSwaps(swaps: SwapData[], opts: { heap?: boolean } = {}): Promise<ProfileResult> {
+        console.log(`\n🔄 Profiling SOR with ${swaps.length} swaps... (heap=${!!opts.heap})`);
 
-        const post = promisify(this.session.post.bind(this.session));
+        const session = new Session();
+        session.connect();
+        const post = promisify(session.post.bind(session));
+
+        // --- Enable profiling domains ---
         await post('Profiler.enable');
-        await post('Profiler.setSamplingInterval', { interval: 100 }); // 100 microseconds
+        await post('Profiler.setSamplingInterval', { interval: 100 });
+        await post('Runtime.enable');
+
+        if (opts.heap) {
+            await post('HeapProfiler.enable');
+            await post('HeapProfiler.startTrackingHeapObjects', { trackAllocations: true });
+            await post('HeapProfiler.startSampling', {
+                samplingInterval: 256 * 1024,
+                stackDepth: 32,
+            });
+        }
+
+        // --- Start CPU profiler ---
         await post('Profiler.start');
-    }
+        const startTime = performance.now();
 
-    private async stopCPUProfiling(): Promise<any> {
-        if (!this.session) return null;
+        console.log(`   Creating SorService instance...`);
+        const sor = new SorService();
 
-        const post = promisify(this.session.post.bind(this.session));
-        const profile = await post('Profiler.stop');
+        let successful = 0;
+        let failed = 0;
+        const comparisons: SwapComparison[] = [];
+
+        for (const swap of swaps) {
+            try {
+                const sorResult = await sor.getSorSwapPaths({
+                    tokenIn: swap.tokenIn,
+                    tokenOut: swap.tokenOut,
+                    swapAmount: swap.amount,
+                    swapType: 'EXACT_IN',
+                    chain: 'MAINNET',
+                });
+                successful++;
+                
+                // Compare SOR result with actual swap output
+                if (sorResult.returnAmount && swap.amountOutScaled) {
+                    const sorAmount = parseFloat(sorResult.returnAmount);
+                    const actualAmount = parseFloat(swap.amountOutScaled);
+                    const deviation = sorAmount - actualAmount;
+                    const deviationPercent = actualAmount !== 0 ? (deviation / actualAmount) * 100 : 0;
+                    
+                    comparisons.push({
+                        swap,
+                        sorReturnAmount: sorResult.returnAmount,
+                        actualAmountOut: swap.amountOutScaled,
+                        deviation,
+                        deviationPercent,
+                    });
+                }
+                
+                if (successful % 10 === 0) process.stdout.write('.');
+            } catch {
+                failed++;
+            }
+        }
+
+        console.log('');
+        const duration = performance.now() - startTime;
+
+        // --- Stop CPU profiler ---
+        const { profile } = await post('Profiler.stop');
+
+        let heapProfile: any = null;
+        if (opts.heap) {
+            const { profile: hp } = await post('HeapProfiler.stopSampling');
+            heapProfile = hp;
+            await post('HeapProfiler.stopTrackingHeapObjects');
+            await post('HeapProfiler.disable');
+        }
+
+        // --- Disable domains ---
+        await post('Runtime.disable');
         await post('Profiler.disable');
+        session.disconnect();
 
-        this.session.disconnect();
-        this.session = null;
+        // --- Save profiles ---
+        if (profile) this.saveProfile(profile, 'cpuprofile');
+        if (heapProfile) this.saveProfile(heapProfile, 'heapprofile');
 
-        return profile.profile;
+        // --- Analyze comparisons ---
+        const biggestDeviations = this.analyzeComparisons(comparisons);
+        
+        // --- Analyze CPU profile ---
+        if (profile) {
+            const analysis = this.analyzeProfile(profile);
+            this.printResults(successful, failed, duration, swaps.length, analysis, biggestDeviations);
+
+            return {
+                successful,
+                failed,
+                duration,
+                avgPerSwap: duration / swaps.length,
+                topFunctions: analysis,
+                comparisons,
+                biggestDeviations,
+            };
+        }
+
+        return { 
+            successful, 
+            failed, 
+            duration, 
+            avgPerSwap: duration / swaps.length,
+            comparisons,
+            biggestDeviations,
+        };
+    }
+    
+    private analyzeComparisons(comparisons: SwapComparison[]): SwapComparison[] {
+        if (comparisons.length === 0) return [];
+        
+        // Sort by absolute deviation percentage
+        const sorted = [...comparisons].sort((a, b) => 
+            Math.abs(b.deviationPercent) - Math.abs(a.deviationPercent)
+        );
+        
+        // Log summary statistics
+        const avgDeviation = comparisons.reduce((sum, c) => sum + Math.abs(c.deviationPercent), 0) / comparisons.length;
+        const betterCount = comparisons.filter(c => c.deviation > 0).length;
+        const worseCount = comparisons.filter(c => c.deviation < 0).length;
+        const exactCount = comparisons.filter(c => Math.abs(c.deviation) < 0.000001).length;
+        
+        console.log('\n📊 SOR vs Actual Comparison:');
+        console.log(`   Total comparisons: ${comparisons.length}`);
+        console.log(`   Average deviation: ${avgDeviation.toFixed(2)}%`);
+        console.log(`   SOR better: ${betterCount} (${(betterCount / comparisons.length * 100).toFixed(1)}%)`);
+        console.log(`   SOR worse: ${worseCount} (${(worseCount / comparisons.length * 100).toFixed(1)}%)`);
+        console.log(`   Exact match: ${exactCount}`);
+        
+        // Return top 10 biggest deviations
+        return sorted.slice(0, 10);
     }
 
-    private analyzeCPUProfile(profile: any): CPUProfile {
+    private analyzeProfile(profile: any): any[] {
         const nodes = profile.nodes;
         const samples = profile.samples;
         const timeDeltas = profile.timeDeltas;
 
-        // Build node map
-        const nodeMap = new Map<number, any>();
-        for (const node of nodes) {
-            nodeMap.set(node.id, node);
-        }
-
-        // Calculate time spent in each function
-        const functionTimes = new Map<number, { self: number; total: number; count: number }>();
-        let currentTime = profile.startTime;
+        const functionTimes = new Map<number, { self: number; count: number }>();
+        const nodeMap = new Map(nodes.map((n: any) => [n.id, n]));
 
         for (let i = 0; i < samples.length; i++) {
             const nodeId = samples[i];
             const delta = timeDeltas[i];
 
-            // Update self time for the sampled node
             if (!functionTimes.has(nodeId)) {
-                functionTimes.set(nodeId, { self: 0, total: 0, count: 0 });
+                functionTimes.set(nodeId, { self: 0, count: 0 });
             }
+
             const times = functionTimes.get(nodeId)!;
             times.self += delta;
             times.count++;
-
-            // Update total time for all ancestors
-            let currentNode = nodeMap.get(nodeId);
-            while (currentNode) {
-                if (!functionTimes.has(currentNode.id)) {
-                    functionTimes.set(currentNode.id, { self: 0, total: 0, count: 0 });
-                }
-                functionTimes.get(currentNode.id)!.total += delta;
-
-                if (currentNode.parent) {
-                    currentNode = nodeMap.get(currentNode.parent);
-                } else {
-                    break;
-                }
-            }
-
-            currentTime += delta;
         }
 
-        const totalTime = currentTime - profile.startTime;
+        const totalTime = timeDeltas.reduce((sum: number, d: number) => sum + d, 0);
 
-        // Convert to function profiles
-        const functionProfiles: FunctionProfile[] = [];
+        return Array.from(functionTimes.entries())
+            .map(([nodeId, times]) => {
+                const node = nodeMap.get(nodeId) as any;
+                if (!node?.callFrame) return null;
 
-        for (const [nodeId, times] of functionTimes.entries()) {
-            const node = nodeMap.get(nodeId);
-            if (!node || !node.callFrame) continue;
-
-            const callFrame = node.callFrame;
-            const functionName = callFrame.functionName || '(anonymous)';
-
-            // Filter out system/runtime functions
-            if (functionName.startsWith('(') && functionName.endsWith(')')) continue;
-
-            functionProfiles.push({
-                functionName,
-                file: callFrame.url || 'unknown',
-                line: callFrame.lineNumber || 0,
-                selfTime: times.self,
-                totalTime: times.total,
-                callCount: times.count,
-                percentOfTotal: (times.self / totalTime) * 100,
-            });
-        }
-
-        // Sort by self time
-        functionProfiles.sort((a, b) => b.selfTime - a.selfTime);
-
-        return {
-            topFunctions: functionProfiles.slice(0, 50),
-            totalTime: totalTime / 1000, // Convert to milliseconds
-            profileData: profile,
-        };
+                return {
+                    functionName: node.callFrame.functionName || '(anonymous)',
+                    file: node.callFrame.url || 'unknown',
+                    selfTime: times.self,
+                    callCount: times.count,
+                    percentOfTotal: (times.self / totalTime) * 100,
+                };
+            })
+            .filter(Boolean)
+            .sort((a, b) => b!.selfTime - a!.selfTime)
+            .slice(0, 10);
     }
 
-    private formatFunctionName(func: FunctionProfile): string {
-        const fileName = func.file.split('/').pop() || func.file;
-        return `${func.functionName} (${fileName}:${func.line})`;
-    }
-
-    private async profileSingleSwap(config: SwapConfig, iterations: number = 100): Promise<CPUProfile> {
-        console.log(`\n🔄 Profiling Original SOR: ${config.name}`);
-        console.log(`   Running ${iterations} iterations with CPU profiling...`);
-
-        // Warm up (without profiling)
-        console.log('   Warming up...');
-        for (let i = 0; i < 5; i++) {
-            try {
-                await this.originalSor.getSorSwapPaths(config as QuerySorGetSwapPathsArgs);
-            } catch (error) {
-                // Continue even if swap fails
-            }
-        }
-
-        // Start CPU profiling
-        await this.startCPUProfiling();
-
-        const startTime = performance.now();
-        let successfulSwaps = 0;
-        let failedSwaps = 0;
-
-        // Run the swap multiple times
-        for (let i = 0; i < iterations; i++) {
-            try {
-                await this.originalSor.getSorSwapPaths(config as QuerySorGetSwapPathsArgs);
-                successfulSwaps++;
-            } catch (error) {
-                failedSwaps++;
-            }
-        }
-
-        const endTime = performance.now();
-        const totalDuration = endTime - startTime;
-
-        // Stop profiling and analyze
-        const profile = await this.stopCPUProfiling();
-        const analysis = this.analyzeCPUProfile(profile);
-
-        // Save raw profile for Chrome DevTools
-        const timestamp = new Date().toISOString().replace(/:/g, '-').split('.')[0];
-        const profilePath = path.join(this.profilesDir, `${config.name.replace(/\s+/g, '-')}-${timestamp}.cpuprofile`);
+    private saveProfile(profile: any, type: 'cpuprofile' | 'heapprofile'): void {
+        ensureDirectory(CONFIG.defaults.dataDir);
+        const profilePath = path.join(CONFIG.defaults.dataDir, `profile-${formatTimestamp()}.${type}`);
         fs.writeFileSync(profilePath, JSON.stringify(profile, null, 2));
-
-        console.log(`   ✅ Successful swaps: ${successfulSwaps}/${iterations}`);
-        if (failedSwaps > 0) {
-            console.log(`   ⚠️  Failed swaps: ${failedSwaps}`);
-        }
-        console.log(`   ⏱️  Total time: ${totalDuration.toFixed(2)}ms`);
-        console.log(`   ⏱️  Average per swap: ${(totalDuration / iterations).toFixed(2)}ms`);
-        console.log(`   📁 Profile saved: ${profilePath}`);
-
-        return analysis;
+        console.log(`📁 ${type.toUpperCase()} saved: ${profilePath}`);
     }
 
-    private printFunctionBreakdown(profile: CPUProfile, limit: number = 20): void {
-        console.log(`\n📊 Top ${limit} Functions by CPU Time:`);
-        console.log('─'.repeat(100));
-        console.log(
-            'Function'.padEnd(50) +
-                'Self Time'.padEnd(12) +
-                'Total Time'.padEnd(12) +
-                'Calls'.padEnd(10) +
-                '% of Total',
-        );
-        console.log('─'.repeat(100));
-
-        const topFunctions = profile.topFunctions.slice(0, limit);
-
-        for (const func of topFunctions) {
-            const funcName = this.formatFunctionName(func);
-            const truncatedName = funcName.length > 48 ? funcName.substring(0, 45) + '...' : funcName;
-
-            console.log(
-                truncatedName.padEnd(50) +
-                    `${(func.selfTime / 1000).toFixed(2)}ms`.padEnd(12) +
-                    `${(func.totalTime / 1000).toFixed(2)}ms`.padEnd(12) +
-                    func.callCount.toString().padEnd(10) +
-                    `${func.percentOfTotal.toFixed(1)}%`,
-            );
-        }
-    }
-
-    private identifyHotspots(profile: CPUProfile): void {
-        console.log('\n🔥 Performance Hotspots in Original SOR:');
-        console.log('─'.repeat(80));
-
-        // Group functions by category
-        const categories = {
-            pathFinding: [] as FunctionProfile[],
-            poolOperations: [] as FunctionProfile[],
-            optimization: [] as FunctionProfile[],
-            validation: [] as FunctionProfile[],
-            calculations: [] as FunctionProfile[],
-            utils: [] as FunctionProfile[],
-            other: [] as FunctionProfile[],
-        };
-
-        for (const func of profile.topFunctions) {
-            const name = func.functionName.toLowerCase();
-            const file = func.file.toLowerCase();
-
-            if (name.includes('path') || name.includes('route') || file.includes('path')) {
-                categories.pathFinding.push(func);
-            } else if (name.includes('pool') || file.includes('pool')) {
-                categories.poolOperations.push(func);
-            } else if (name.includes('optim') || name.includes('best') || name.includes('sort')) {
-                categories.optimization.push(func);
-            } else if (name.includes('valid') || name.includes('check') || name.includes('filter')) {
-                categories.validation.push(func);
-            } else if (name.includes('calc') || name.includes('compute') || name.includes('amount')) {
-                categories.calculations.push(func);
-            } else if (file.includes('util') || name.includes('format') || name.includes('parse')) {
-                categories.utils.push(func);
-            } else {
-                categories.other.push(func);
+    private printResults(
+        successful: number,
+        failed: number,
+        duration: number,
+        total: number,
+        topFunctions?: any[],
+        biggestDeviations?: SwapComparison[],
+    ): void {
+        console.log(`\n📊 Results:`);
+        console.log(`   Successful: ${successful}/${total}`);
+        console.log(`   Failed: ${failed}`);
+        console.log(`   Total time: ${duration.toFixed(2)}ms`);
+        console.log(`   Avg per swap: ${(duration / total).toFixed(2)}ms`);
+        
+        // Print biggest deviations
+        if (biggestDeviations && biggestDeviations.length > 0) {
+            console.log(`\n🎯 Biggest Deviations (SOR vs Actual):`);
+            for (let i = 0; i < Math.min(5, biggestDeviations.length); i++) {
+                const comp = biggestDeviations[i];
+                const sign = comp.deviation > 0 ? '+' : '';
+                console.log(`   ${i + 1}. ${comp.swap.tokenIn.slice(0, 6)}...${comp.swap.tokenIn.slice(-4)} → ${comp.swap.tokenOut.slice(0, 6)}...${comp.swap.tokenOut.slice(-4)}`);
+                console.log(`      Amount In: ${parseFloat(comp.swap.amount).toFixed(4)}`);
+                console.log(`      SOR Output: ${parseFloat(comp.sorReturnAmount).toFixed(4)}`);
+                console.log(`      Actual Output: ${parseFloat(comp.actualAmountOut).toFixed(4)}`);
+                console.log(`      Deviation: ${sign}${comp.deviation.toFixed(6)} (${sign}${comp.deviationPercent.toFixed(2)}%)`);
+                console.log(`      ${comp.deviation > 0 ? '✅ SOR found better path' : '⚠️  SOR predicted worse'}`);
             }
         }
 
-        // Calculate and display category totals
-        for (const [category, functions] of Object.entries(categories)) {
-            if (functions.length === 0) continue;
-
-            const totalTime = functions.reduce((sum, f) => sum + f.selfTime, 0);
-            const percent = (totalTime / (profile.totalTime * 1000)) * 100;
-
-            if (percent > 1) {
-                // Only show categories with >1% CPU usage
-                console.log(`\n${category.charAt(0).toUpperCase() + category.slice(1)}:`);
-                console.log(`  Total CPU: ${percent.toFixed(1)}%`);
-                console.log(`  Top functions:`);
-
-                const topInCategory = functions.sort((a, b) => b.selfTime - a.selfTime).slice(0, 3);
-
-                for (const func of topInCategory) {
-                    console.log(`    - ${func.functionName}: ${func.percentOfTotal.toFixed(1)}%`);
-                }
+        if (topFunctions && topFunctions.length > 0) {
+            console.log(`\n🔥 Top Functions:`);
+            for (let i = 0; i < Math.min(5, topFunctions.length); i++) {
+                const func = topFunctions[i];
+                const fileName = func.file.split('/').pop() || func.file;
+                console.log(`   ${func.percentOfTotal.toFixed(1)}% - ${func.functionName} (${fileName})`);
             }
-        }
-    }
-
-    private async generateFlameGraph(profile: CPUProfile, name: string): Promise<void> {
-        console.log('\n🔥 Generating Flame Graph Data...');
-
-        // Convert profile to collapsed stack format for flamegraph
-        const stacks: string[] = [];
-        const nodes = profile.profileData.nodes;
-        const samples = profile.profileData.samples;
-        const timeDeltas = profile.profileData.timeDeltas;
-
-        // Build node map
-        const nodeMap = new Map<number, any>();
-        for (const node of nodes) {
-            nodeMap.set(node.id, node);
-        }
-
-        // Process each sample
-        for (let i = 0; i < samples.length; i++) {
-            const nodeId = samples[i];
-            const weight = timeDeltas[i];
-
-            // Build stack trace
-            const stack: string[] = [];
-            let currentNode = nodeMap.get(nodeId);
-
-            while (currentNode) {
-                if (currentNode.callFrame) {
-                    const frame = currentNode.callFrame;
-                    const funcName = frame.functionName || '(anonymous)';
-                    const fileName = (frame.url || 'unknown').split('/').pop();
-                    stack.unshift(`${funcName} (${fileName})`);
-                }
-
-                if (currentNode.parent) {
-                    currentNode = nodeMap.get(currentNode.parent);
-                } else {
-                    break;
-                }
-            }
-
-            if (stack.length > 0) {
-                stacks.push(`${stack.join(';')} ${weight}`);
-            }
-        }
-
-        // Save collapsed stacks
-        const timestamp = new Date().toISOString().replace(/:/g, '-').split('.')[0];
-        const stacksPath = path.join(this.profilesDir, `${name}-stacks-${timestamp}.txt`);
-        fs.writeFileSync(stacksPath, stacks.join('\n'));
-
-        console.log(`   📁 Collapsed stacks saved: ${stacksPath}`);
-        console.log(`   💡 To generate flamegraph:`);
-        console.log(`      1. Install: npm install -g flamegraph`);
-        console.log(`      2. Generate: flamegraph ${stacksPath} > ${name}.svg`);
-    }
-
-    async runDetailedProfiling(configs?: SwapConfig[]): Promise<void> {
-        const defaultConfigs: SwapConfig[] = [
-            {
-                name: 'Small-ETH-USDC',
-                tokenIn: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', // WETH
-                tokenOut: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDC
-                swapAmount: '0.1',
-                swapType: 'EXACT_IN',
-                chain: 'MAINNET',
-            },
-            {
-                name: 'Medium-ETH-USDC',
-                tokenIn: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', // WETH
-                tokenOut: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDC
-                swapAmount: '1',
-                swapType: 'EXACT_IN',
-                chain: 'MAINNET',
-            },
-            {
-                name: 'Large-ETH-USDC',
-                tokenIn: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', // WETH
-                tokenOut: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDC
-                swapAmount: '100',
-                swapType: 'EXACT_IN',
-                chain: 'MAINNET',
-            },
-        ];
-
-        const swapConfigs = configs || defaultConfigs;
-
-        console.log('🚀 Original SOR CPU Profiling Analysis');
-        console.log('='.repeat(80));
-        console.log('This will generate detailed CPU profiles for the original SOR implementation');
-        console.log('Profiles will be saved in: ' + this.profilesDir);
-        console.log('');
-
-        const allProfiles: { config: SwapConfig; profile: CPUProfile }[] = [];
-
-        for (const config of swapConfigs) {
-            const profile = await this.profileSingleSwap(config, 50);
-            this.printFunctionBreakdown(profile, 15);
-            this.identifyHotspots(profile);
-            await this.generateFlameGraph(profile, `original-${config.name}`);
-
-            allProfiles.push({ config, profile });
-        }
-
-        // Summary comparison across different swap sizes
-        if (allProfiles.length > 1) {
-            console.log('\n📊 Performance Summary Across Swap Sizes:');
-            console.log('─'.repeat(80));
-
-            for (const { config, profile } of allProfiles) {
-                console.log(`\n${config.name}:`);
-                console.log(`  Total profiling time: ${profile.totalTime.toFixed(2)}ms`);
-                console.log(
-                    `  Top CPU consumer: ${profile.topFunctions[0]?.functionName || 'N/A'} (${profile.topFunctions[0]?.percentOfTotal.toFixed(1)}%)`,
-                );
-            }
-        }
-
-        console.log('\n✅ Profiling complete!');
-        console.log('\n📖 How to analyze the profiles:');
-        console.log('1. Open Chrome DevTools (F12)');
-        console.log('2. Go to Performance tab');
-        console.log('3. Click "Load profile" button (up arrow icon)');
-        console.log('4. Select a .cpuprofile file from: ' + this.profilesDir);
-        console.log('\nThis will show you:');
-        console.log('- Call tree with time spent in each function');
-        console.log('- Flame chart visualization');
-        console.log('- Bottom-up view of expensive functions');
-    }
-
-    async profileWithMemory(): Promise<void> {
-        console.log('\n💾 Profiling with Memory Analysis...');
-
-        // Take initial heap snapshot
-        this.takeHeapSnapshot('before');
-        const initialMemory = process.memoryUsage();
-
-        const config: SwapConfig = {
-            name: 'Memory-Profile',
-            tokenIn: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-            tokenOut: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-            swapAmount: '10',
-            swapType: 'EXACT_IN',
-            chain: 'MAINNET',
-        };
-
-        // Run profiling
-        const profile = await this.profileSingleSwap(config, 20);
-
-        // Take final heap snapshot
-        this.takeHeapSnapshot('after');
-        const finalMemory = process.memoryUsage();
-
-        // Memory analysis
-        console.log('\n💾 Memory Usage:');
-        console.log(
-            `   Heap Used: ${((finalMemory.heapUsed - initialMemory.heapUsed) / 1024 / 1024).toFixed(2)} MB increase`,
-        );
-        console.log(`   Total Heap: ${(finalMemory.heapTotal / 1024 / 1024).toFixed(2)} MB`);
-        console.log(`   External: ${(finalMemory.external / 1024 / 1024).toFixed(2)} MB`);
-        console.log(`   RSS: ${(finalMemory.rss / 1024 / 1024).toFixed(2)} MB`);
-    }
-
-    private takeHeapSnapshot(name: string): void {
-        const heapSnapshotPath = path.join(this.profilesDir, `heap-${name}-${Date.now()}.heapsnapshot`);
-        const heapSnapshot = v8.writeHeapSnapshot();
-
-        if (heapSnapshot) {
-            fs.writeFileSync(heapSnapshotPath, heapSnapshot);
-            console.log(`📸 Heap snapshot saved: ${heapSnapshotPath}`);
         }
     }
 }
 
-// Main execution
-async function main() {
-    const args = process.argv.slice(2);
+// 3. CLI Handler
+class CLI {
+    private fetcher = new SwapDataFetcher();
+    private profiler = new SorProfiler();
 
-    if (args.includes('--help') || args.includes('-h')) {
+    async run(args: string[]): Promise<void> {
+        const options = this.parseArgs(args);
+
+        if (options.help) {
+            this.printHelp();
+            return;
+        }
+
+        if (options.fetchOnly) {
+            // Just fetch and save swaps
+            await this.fetcher.fetchAndSaveSwaps(options.count);
+            return;
+        }
+
+        // Determine swap source
+        let swaps: SwapData[] = [];
+
+        if (options.singleSwap) {
+            // Use single swap from CLI params
+            swaps = [options.singleSwap];
+            console.log(`\n📝 Using single swap from CLI params`);
+        } else if (options.file) {
+            // Load from specified file
+            swaps = this.loadSwapsFromFile(options.file);
+            console.log(`\n📂 Loaded ${swaps.length} swaps from: ${options.file}`);
+        } else {
+            // Try to load from default file, or fetch new ones
+            const defaultFile = getSwapsFilePath();
+            if (fs.existsSync(defaultFile)) {
+                swaps = this.loadSwapsFromFile(defaultFile);
+                console.log(`\n📂 Loaded ${swaps.length} swaps from: ${defaultFile}`);
+            } else {
+                console.log(`\n🔄 No saved swaps found. Fetching new ones...`);
+                const filePath = await this.fetcher.fetchAndSaveSwaps(options.count);
+                swaps = this.loadSwapsFromFile(filePath);
+            }
+        }
+
+        if (swaps.length === 0) {
+            console.error('❌ No swaps to test');
+            process.exit(1);
+        }
+
+        // Profile the swaps
+        await this.profiler.profileSwaps(swaps);
+    }
+
+    private parseArgs(args: string[]): any {
+        const options: any = {
+            help: args.includes('--help') || args.includes('-h'),
+            fetchOnly: false,
+            count: CONFIG.defaults.swapCount,
+            file: null,
+            singleSwap: null,
+        };
+
+        // Parse fetch-only mode
+        const fetchIndex = args.indexOf('--fetch');
+        if (fetchIndex !== -1) {
+            options.fetchOnly = true;
+            if (args[fetchIndex + 1] && !args[fetchIndex + 1].startsWith('--')) {
+                options.count = parseInt(args[fetchIndex + 1]) || CONFIG.defaults.swapCount;
+            }
+        }
+
+        // Parse count
+        const countIndex = args.indexOf('--count');
+        if (countIndex !== -1 && args[countIndex + 1]) {
+            options.count = parseInt(args[countIndex + 1]) || CONFIG.defaults.swapCount;
+        }
+
+        // Parse file
+        const fileIndex = args.indexOf('--file');
+        if (fileIndex !== -1 && args[fileIndex + 1]) {
+            options.file = args[fileIndex + 1];
+        }
+
+        // Parse single swap
+        const swapIndex = args.indexOf('--swap');
+        if (swapIndex !== -1 && args[swapIndex + 1]) {
+            const parts = args[swapIndex + 1].split(',');
+            if (parts.length === 3) {
+                options.singleSwap = {
+                    tokenIn: parts[0],
+                    tokenOut: parts[1],
+                    amount: parts[2],
+                };
+            } else {
+                console.error('❌ Invalid swap format. Use: --swap tokenIn,tokenOut,amount');
+                process.exit(1);
+            }
+        }
+
+        return options;
+    }
+
+    private loadSwapsFromFile(filePath: string): SwapData[] {
+        try {
+            const data = fs.readFileSync(filePath, 'utf-8');
+            return JSON.parse(data);
+        } catch (error) {
+            console.error(`❌ Failed to load swaps from ${filePath}:`, error);
+            return [];
+        }
+    }
+
+    private printHelp(): void {
         console.log(`
-Original SOR CPU Profiling Script
+SOR CPU Profiling Tool
 
-Usage: node --loader tsx scripts/profile-original-sor.ts [options]
+Usage: npx tsx scripts/profile-sor.ts [options]
 
 Options:
-  --iterations <n>   Number of swap iterations per test (default: 50)
-  --memory          Include memory profiling
-  --help            Show this help message
+  --fetch [count]              Fetch and save swap data only (default: ${CONFIG.defaults.swapCount})
+  --file <path>                Use swaps from specified file
+  --swap <in,out,amount>       Test single swap (e.g., --swap 0xC02aa...,0x6B17...,1.5)
+  --count <n>                  Number of swaps to fetch (default: ${CONFIG.defaults.swapCount})
+  --help                       Show this help
 
-The script generates:
-  1. CPU profiles (.cpuprofile) - Load in Chrome DevTools
-  2. Collapsed stacks (.txt) - For flamegraph generation
-  3. Heap snapshots (.heapsnapshot) - Memory analysis (with --memory flag)
+Examples:
+  # Fetch latest 200 swaps and save to file
+  npx tsx scripts/profile-sor.ts --fetch 200
 
-Output directory: ./profiles/original-sor/
+  # Test with previously saved swaps
+  npx tsx scripts/profile-sor.ts --file profiles/real-swaps/latest-swaps.json
 
-To view CPU profiles:
-  1. Open Chrome DevTools (F12)
-  2. Go to Performance tab
-  3. Click "Load profile" (up arrow icon)
-  4. Select the .cpuprofile file
+  # Test single swap
+  npx tsx scripts/profile-sor.ts --swap 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2,0x6B175474E89094C44Da98b954EedeAC495271d0F,1.5
 
-To generate flamegraphs:
-  1. Install: npm install -g flamegraph
-  2. Generate: flamegraph profiles/original-sor/[name]-stacks.txt > flamegraph.svg
-  3. Open the SVG in a browser
+  # Auto mode: use saved swaps if available, otherwise fetch new ones
+  npx tsx scripts/profile-sor.ts
+
+Data directory: ${CONFIG.defaults.dataDir}/
         `);
-        process.exit(0);
     }
-
-    const profiler = new OriginalSorProfiler();
-
-    console.log('🚀 Starting Original SOR CPU Profiling...');
-    console.log('This will identify performance bottlenecks in the original SOR implementation.\n');
-
-    if (args.includes('--memory')) {
-        await profiler.profileWithMemory();
-    } else {
-        await profiler.runDetailedProfiling();
-    }
-
-    console.log('\n✨ Done! Check the ./profiles/original-sor directory for output files.');
 }
 
-// Run if called directly
+// Main entry point
+async function main() {
+    const cli = new CLI();
+
+    try {
+        await cli.run(process.argv.slice(2));
+        console.log('\n✨ Done!');
+    } catch (error) {
+        console.error('❌ Error:', error);
+        process.exit(1);
+    }
+}
+
 if (require.main === module) {
     main()
-        .catch((error) => {
-            console.error('❌ Profiling failed:', error);
-            process.exit(1);
-        })
+        .catch(console.error)
         .finally(() => process.exit(0));
 }
 
-export { OriginalSorProfiler };
+export { SwapDataFetcher, SorProfiler, SwapData };

--- a/scripts/profile-sor.ts
+++ b/scripts/profile-sor.ts
@@ -26,6 +26,7 @@ import { getViemClient } from '../modules/sources/viem-client';
 import { multicallViem } from '../modules/web3/multicaller-viem';
 import { parseAbiItem } from 'abitype';
 import { formatUnits, getAddress, keccak256, toHex, encodeAbiParameters, parseAbiParameters } from 'viem';
+import { getBasePoolsFromDb, getTokenPricesMap } from '../modules/sor/utils/data';
 
 // Configuration
 const CONFIG = {
@@ -270,10 +271,18 @@ class SwapDataFetcher {
 
 // 2. SOR Profiler - Tests SOR with provided swaps
 class SorProfiler {
-    async profileSwaps(swaps: SwapData[], opts: { heap?: boolean; algorithm?: PathGraphVersion | 'all' } = {}): Promise<ProfileResult> {
+    async profileSwaps(
+        swaps: SwapData[],
+        opts: { heap?: boolean; algorithm?: PathGraphVersion | 'all' } = {},
+    ): Promise<ProfileResult> {
         const algorithm = opts.algorithm || 'original';
         console.log(`\n🔄 Profiling SOR with ${swaps.length} swaps... (heap=${!!opts.heap}, algorithm=${algorithm})`);
-        
+
+        // pre warm by getting pools from DB
+        await getBasePoolsFromDb('MAINNET', 2, true, []);
+        // pre warm by getting token prices
+        await getTokenPricesMap('MAINNET');
+
         // If comparing all algorithms
         if (algorithm === 'all') {
             return await this.compareAllAlgorithms(swaps, opts);
@@ -281,7 +290,13 @@ class SorProfiler {
 
         const session = new Session();
         session.connect();
-        const post = promisify(session.post.bind(session));
+        const post = ((method: string, params?: any) =>
+            new Promise<any>((resolve, reject) => {
+                (session.post as any)(method as any, params as any, (err: any, result: any) => {
+                    if (err) reject(err);
+                    else resolve(result);
+                });
+            })) as (method: string, params?: any) => Promise<any>;
 
         // --- Enable profiling domains ---
         await post('Profiler.enable');
@@ -306,7 +321,6 @@ class SorProfiler {
 
         let successful = 0;
         let failed = 0;
-        const comparisons: SwapComparison[] = [];
 
         for (const swap of swaps) {
             try {
@@ -319,20 +333,11 @@ class SorProfiler {
                 });
                 successful++;
 
-                // Compare SOR result with actual swap output
-                if (sorResult.returnAmount && swap.amountOutScaled) {
-                    const sorAmount = parseFloat(sorResult.returnAmount);
-                    const actualAmount = parseFloat(swap.amountOutScaled);
-                    const deviation = sorAmount - actualAmount;
-                    const deviationPercent = actualAmount !== 0 ? (deviation / actualAmount) * 100 : 0;
-
-                    comparisons.push({
-                        swap,
-                        sorReturnAmount: sorResult.returnAmount,
-                        actualAmountOut: swap.amountOutScaled,
-                        deviation,
-                        deviationPercent,
-                    });
+                // If running a single swap test, print path details immediately
+                if (swaps.length === 1) {
+                    console.log(`\n🔎 Swap path details (${algorithm})`);
+                    console.log(`   Return: ${sorResult.returnAmount}, Paths: ${sorResult.paths?.length || 0}`);
+                    this.printPaths(sorResult.paths || []);
                 }
 
                 if (successful % 10 === 0) process.stdout.write('.');
@@ -345,11 +350,11 @@ class SorProfiler {
         const duration = performance.now() - startTime;
 
         // --- Stop CPU profiler ---
-        const { profile } = await post('Profiler.stop');
+        const { profile } = (await post('Profiler.stop')) as { profile: any };
 
         let heapProfile: any = null;
         if (opts.heap) {
-            const { profile: hp } = await post('HeapProfiler.stopSampling');
+            const { profile: hp } = (await post('HeapProfiler.stopSampling')) as { profile: any };
             heapProfile = hp;
             await post('HeapProfiler.stopTrackingHeapObjects');
             await post('HeapProfiler.disable');
@@ -364,13 +369,10 @@ class SorProfiler {
         if (profile) this.saveProfile(profile, 'cpuprofile');
         if (heapProfile) this.saveProfile(heapProfile, 'heapprofile');
 
-        // --- Analyze comparisons ---
-        const biggestDeviations = this.analyzeComparisons(comparisons);
-
         // --- Analyze CPU profile ---
         if (profile) {
             const analysis = this.analyzeProfile(profile);
-            this.printResults(successful, failed, duration, swaps.length, analysis, biggestDeviations);
+            this.printResults(successful, failed, duration, swaps.length, analysis);
 
             return {
                 successful,
@@ -378,8 +380,6 @@ class SorProfiler {
                 duration,
                 avgPerSwap: duration / swaps.length,
                 topFunctions: analysis,
-                comparisons,
-                biggestDeviations,
             };
         }
 
@@ -388,129 +388,210 @@ class SorProfiler {
             failed,
             duration,
             avgPerSwap: duration / swaps.length,
-            comparisons,
-            biggestDeviations,
         };
     }
 
     private async compareAllAlgorithms(swaps: SwapData[], opts: { heap?: boolean }): Promise<ProfileResult> {
+        type AlgoResult = {
+            duration: number;
+            successful: number;
+            failed: number;
+            amounts: number[];
+            results: Array<{ returnAmount: string; paths: any[] }>; // minimal details for logging
+        };
+        type VsBaseline = { deltas: number[]; deltasPct: number[]; better: number; worse: number; same: number };
+
         const algorithms: PathGraphVersion[] = ['original', 'beamOptimisation', 'bfsOptimisation'];
-        const results: Record<string, { duration: number; successful: number; failed: number; comparisons: SwapComparison[] }> = {};
-        
-        console.log('\n🎬 Comparing all path finding algorithms...');
+        const results: Record<string, AlgoResult> = {};
+
+        console.log('\n🎬 Comparing path finding algorithms (vs original baseline)...');
         console.log('='.repeat(60));
-        
-        for (const algo of algorithms) {
-            console.log(`\n\n🔄 Testing ${algo} algorithm...`);
+
+        // Run baseline first
+        const baselineAlgo: PathGraphVersion = 'original';
+        {
+            console.log(`\n\n🔄 Testing ${baselineAlgo} (baseline) ...`);
             const startTime = performance.now();
-            const sor = new SorService(algo);
-            
+            const sor = new SorService(baselineAlgo);
             let successful = 0;
             let failed = 0;
-            const comparisons: SwapComparison[] = [];
-            
+            const amounts: number[] = [];
+            const detailed: Array<{ returnAmount: string; paths: any[] }> = [];
             for (const swap of swaps) {
                 try {
-                    const sorResult = await sor.getSorSwapPaths({
+                    const res = await sor.getSorSwapPaths({
                         tokenIn: swap.tokenIn,
                         tokenOut: swap.tokenOut,
                         swapAmount: swap.amount,
                         swapType: 'EXACT_IN',
                         chain: 'MAINNET',
                     });
+                    amounts.push(parseFloat(res.returnAmount || '0'));
+                    detailed.push({ returnAmount: res.returnAmount, paths: res.paths || [] });
                     successful++;
-                    
-                    if (sorResult.returnAmount && swap.amountOutScaled) {
-                        const sorAmount = parseFloat(sorResult.returnAmount);
-                        const actualAmount = parseFloat(swap.amountOutScaled);
-                        comparisons.push({
-                            swap,
-                            sorReturnAmount: sorResult.returnAmount,
-                            actualAmountOut: swap.amountOutScaled,
-                            deviation: sorAmount - actualAmount,
-                            deviationPercent: actualAmount !== 0 ? ((sorAmount - actualAmount) / actualAmount) * 100 : 0,
-                        });
-                    }
-                    
                     if (successful % 10 === 0) process.stdout.write('.');
                 } catch {
+                    amounts.push(0);
+                    detailed.push({ returnAmount: '0', paths: [] });
                     failed++;
                 }
             }
-            
             const duration = performance.now() - startTime;
-            results[algo] = { duration, successful, failed, comparisons };
-            
+            results[baselineAlgo] = { duration, successful, failed, amounts, results: detailed };
+            console.log('');
+            console.log(`   ✅ ${baselineAlgo}: ${successful}/${swaps.length} successful in ${duration.toFixed(2)}ms`);
+        }
+
+        // Run other algorithms
+        for (const algo of algorithms.filter((a) => a !== baselineAlgo)) {
+            console.log(`\n\n🔄 Testing ${algo} algorithm...`);
+            const startTime = performance.now();
+            const sor = new SorService(algo);
+            let successful = 0;
+            let failed = 0;
+            const amounts: number[] = [];
+            const detailed: Array<{ returnAmount: string; paths: any[] }> = [];
+            for (const swap of swaps) {
+                try {
+                    const res = await sor.getSorSwapPaths({
+                        tokenIn: swap.tokenIn,
+                        tokenOut: swap.tokenOut,
+                        swapAmount: swap.amount,
+                        swapType: 'EXACT_IN',
+                        chain: 'MAINNET',
+                    });
+                    amounts.push(parseFloat(res.returnAmount || '0'));
+                    detailed.push({ returnAmount: res.returnAmount, paths: res.paths || [] });
+                    successful++;
+                    if (successful % 10 === 0) process.stdout.write('.');
+                } catch {
+                    amounts.push(0);
+                    detailed.push({ returnAmount: '0', paths: [] });
+                    failed++;
+                }
+            }
+            const duration = performance.now() - startTime;
+            results[algo] = { duration, successful, failed, amounts, results: detailed };
             console.log('');
             console.log(`   ✅ ${algo}: ${successful}/${swaps.length} successful in ${duration.toFixed(2)}ms`);
         }
-        
-        // Compare results
-        this.compareAlgorithmResults(results, swaps.length);
-        
-        // Return results for the fastest algorithm
-        const fastest = Object.entries(results).sort((a, b) => a[1].duration - b[1].duration)[0];
+
+        // Compare vs baseline
+        this.compareAgainstBaseline(results, swaps, swaps.length, baselineAlgo);
+
+        // Return fastest non-baseline result summary
+        const nonBaselineEntries = Object.entries(results).filter(([algo]) => algo !== baselineAlgo);
+        const fastest = nonBaselineEntries.sort((a, b) => a[1].duration - b[1].duration)[0];
         return {
             successful: fastest[1].successful,
             failed: fastest[1].failed,
             duration: fastest[1].duration,
             avgPerSwap: fastest[1].duration / swaps.length,
-            comparisons: fastest[1].comparisons,
-            biggestDeviations: this.analyzeComparisons(fastest[1].comparisons),
         };
     }
-    
-    private compareAlgorithmResults(results: Record<string, any>, totalSwaps: number): void {
-        console.log('\n\n📊 Algorithm Comparison Summary:');
+
+    private compareAgainstBaseline(
+        results: Record<
+            string,
+            {
+                duration: number;
+                successful: number;
+                failed: number;
+                amounts: number[];
+                results: Array<{ returnAmount: string; paths: any[] }>;
+            }
+        >,
+        swaps: SwapData[],
+        totalSwaps: number,
+        baselineAlgo: string,
+    ): void {
+        console.log('\n\n📊 Algorithm Comparison (vs original baseline):');
         console.log('='.repeat(60));
-        
-        // Sort by duration
-        const sorted = Object.entries(results).sort((a, b) => a[1].duration - b[1].duration);
-        
+
+        const baseline = results[baselineAlgo].amounts;
+
+        // Performance ranking
         console.log('\n⏱️  Performance Ranking:');
-        sorted.forEach(([algo, data], index) => {
-            const speedup = index > 0 ? ((sorted[0][1].duration / data.duration - 1) * 100).toFixed(1) : '0';
-            console.log(`   ${index + 1}. ${algo}:`);
-            console.log(`      Duration: ${data.duration.toFixed(2)}ms`);
-            console.log(`      Avg/swap: ${(data.duration / totalSwaps).toFixed(2)}ms`);
-            console.log(`      Success rate: ${((data.successful / totalSwaps) * 100).toFixed(1)}%`);
-            if (index > 0) {
-                console.log(`      Speedup vs fastest: ${speedup}%`);
-            }
-        });
-        
-        // Compare output quality
-        console.log('\n🎯 Output Quality Comparison:');
+        const perfSorted = Object.entries(results)
+            .sort((a, b) => a[1].duration - b[1].duration)
+            .map(([algo, data], index) => {
+                const speedup = (results[baselineAlgo].duration / data.duration - 1) * 100;
+                console.log(`   ${index + 1}. ${algo}:`);
+                console.log(`      Duration: ${data.duration.toFixed(2)}ms`);
+                console.log(`      Avg/swap: ${(data.duration / totalSwaps).toFixed(2)}ms`);
+                console.log(`      Success rate: ${((data.successful / totalSwaps) * 100).toFixed(1)}%`);
+                if (algo !== baselineAlgo) {
+                    console.log(`      Speedup vs baseline: ${speedup.toFixed(1)}%`);
+                }
+                return { algo, data };
+            });
+
+        // Output comparison vs baseline
+        console.log('\n🎯 Return Amounts vs Baseline (EXACT_IN; higher is better):');
         for (const [algo, data] of Object.entries(results)) {
-            if (data.comparisons.length > 0) {
-                const avgDeviation = data.comparisons.reduce((sum: number, c: SwapComparison) => 
-                    sum + Math.abs(c.deviationPercent), 0) / data.comparisons.length;
-                const betterCount = data.comparisons.filter((c: SwapComparison) => c.deviation > 0).length;
-                
-                console.log(`   ${algo}:`);
-                console.log(`      Avg deviation: ${avgDeviation.toFixed(2)}%`);
-                console.log(`      Found better paths: ${betterCount}/${data.comparisons.length}`);
-            }
-        }
-        
-        // Check if all algorithms return same results
-        const returnAmounts = Object.entries(results).map(([algo, data]) => {
-            return data.comparisons.map((c: SwapComparison) => c.sorReturnAmount);
-        });
-        
-        if (returnAmounts.length > 1) {
-            let allSame = true;
-            for (let i = 0; i < returnAmounts[0].length; i++) {
-                const amounts = returnAmounts.map(amounts => amounts[i]);
-                if (amounts.some(a => a !== amounts[0])) {
-                    allSame = false;
-                    break;
+            if (algo === baselineAlgo) continue;
+            const deltas: number[] = [];
+            const deltasPct: number[] = [];
+            let better = 0,
+                worse = 0,
+                same = 0;
+            for (let i = 0; i < baseline.length; i++) {
+                const base = baseline[i] || 0;
+                const val = data.amounts[i] || 0;
+                const delta = val - base;
+                const pct = base !== 0 ? (delta / base) * 100 : 0;
+                deltas.push(delta);
+                if (Math.abs(delta) < 1e-12) same++;
+                else {
+                    deltasPct.push(pct);
+                    if (delta > 0) better++;
+                    else worse++;
                 }
             }
-            console.log(`\n🔍 Result Consistency: ${allSame ? '✅ All algorithms return same amounts' : '⚠️  Algorithms return different amounts'}`);
+            const avgPct = deltasPct.reduce((s, v) => s + v, 0) / deltasPct.length;
+            console.log(`   ${algo}:`);
+            console.log(`      Avg delta % vs baseline: ${avgPct.toFixed(4)}%`);
+            console.log(`      Better: ${better}, Worse: ${worse}, Same: ${same}`);
+
+            // Detailed logs for worse cases to understand path differences
+            const maxLogs = 10;
+            let logged = 0;
+            for (let i = 0; i < baseline.length && logged < maxLogs; i++) {
+                const baseVal = baseline[i] || 0;
+                const curVal = data.amounts[i] || 0;
+                if (curVal <= baseVal && Math.abs(curVal - baseVal) > 1e-12) {
+                    const swap = swaps[i];
+                    const baseRes = results[baselineAlgo].results[i];
+                    const curRes = data.results[i];
+                    console.log(`\n   🔎 Swap #${i + 1}: ${swap.tokenIn} -> ${swap.tokenOut} amount=${swap.amount}`);
+                    console.log(
+                        `      Baseline(${baselineAlgo}) return=${baseRes.returnAmount}, paths=${baseRes.paths.length}`,
+                    );
+                    this.printPaths(baseRes.paths);
+                    console.log(`      ${algo} return=${curRes.returnAmount}, paths=${curRes.paths.length}`);
+                    this.printPaths(curRes.paths);
+                    logged++;
+                }
+            }
         }
     }
-    
+
+    private printPaths(paths: any[]): void {
+        for (let p = 0; p < paths.length; p++) {
+            const path = paths[p];
+            const tokenSeq = Array.isArray(path.tokens) ? path.tokens.map((t: any) => t.address).join(' -> ') : '';
+            const poolSeq = Array.isArray(path.pools) ? path.pools.join(' , ') : '';
+            const inRaw = path.inputAmountRaw || '0';
+            const outRaw = path.outputAmountRaw || '0';
+            console.log(`         Path ${p + 1}: tokens=[${tokenSeq}]`);
+            console.log(`                  pools=[${poolSeq}]`);
+            console.log(`                  inRaw=${inRaw} outRaw=${outRaw}`);
+        }
+        if (paths.length === 0) {
+            console.log('         (no paths)');
+        }
+    }
+
     private analyzeComparisons(comparisons: SwapComparison[]): SwapComparison[] {
         if (comparisons.length === 0) return [];
 
@@ -603,13 +684,17 @@ class SorProfiler {
                 const comp = biggestDeviations[i];
                 const sign = comp.deviation > 0 ? '+' : '';
                 console.log(
-                    `   ${i + 1}. ${comp.swap.tokenIn.slice(0, 6)}...${comp.swap.tokenIn.slice(-4)} → ${comp.swap.tokenOut.slice(0, 6)}...${comp.swap.tokenOut.slice(-4)}`,
+                    `   ${i + 1}. ${comp.swap.tokenIn.slice(0, 6)}...${comp.swap.tokenIn.slice(
+                        -4,
+                    )} → ${comp.swap.tokenOut.slice(0, 6)}...${comp.swap.tokenOut.slice(-4)}`,
                 );
                 console.log(`      Amount In: ${parseFloat(comp.swap.amount).toFixed(4)}`);
                 console.log(`      SOR Output: ${parseFloat(comp.sorReturnAmount).toFixed(4)}`);
                 console.log(`      Actual Output: ${parseFloat(comp.actualAmountOut).toFixed(4)}`);
                 console.log(
-                    `      Deviation: ${sign}${comp.deviation.toFixed(6)} (${sign}${comp.deviationPercent.toFixed(2)}%)`,
+                    `      Deviation: ${sign}${comp.deviation.toFixed(6)} (${sign}${comp.deviationPercent.toFixed(
+                        2,
+                    )}%)`,
                 );
                 console.log(`      ${comp.deviation > 0 ? '✅ SOR found better path' : '⚠️  SOR predicted worse'}`);
             }
@@ -675,9 +760,9 @@ class CLI {
         }
 
         // Profile the swaps
-        await this.profiler.profileSwaps(swaps, { 
+        await this.profiler.profileSwaps(swaps, {
             heap: options.heap,
-            algorithm: options.algorithm 
+            algorithm: options.algorithm,
         });
     }
 
@@ -706,20 +791,18 @@ class CLI {
         if (countIndex !== -1 && args[countIndex + 1]) {
             options.count = parseInt(args[countIndex + 1]) || CONFIG.defaults.swapCount;
         }
-        
+
         // Parse heap
         if (args.includes('--heap')) {
             options.heap = true;
         }
-        
+
         // Parse algorithm
         const algoIndex = args.indexOf('--algorithm');
         if (algoIndex !== -1 && args[algoIndex + 1]) {
             const algo = args[algoIndex + 1];
             if (algo === 'all' || algo === 'original' || algo === 'beam' || algo === 'bfs') {
-                options.algorithm = algo === 'beam' ? 'beamOptimisation' : 
-                                  algo === 'bfs' ? 'bfsOptimisation' : 
-                                  algo;
+                options.algorithm = algo === 'beam' ? 'beamOptimisation' : algo === 'bfs' ? 'bfsOptimisation' : algo;
             }
         }
 

--- a/scripts/profile-sor.ts
+++ b/scripts/profile-sor.ts
@@ -20,6 +20,7 @@ import * as path from 'path';
 import { Session } from 'inspector';
 import { promisify } from 'util';
 import { SorService } from '../modules/sor/sor.service';
+import { PathGraphVersion } from '../modules/sor/lib/router';
 import mainnetConfig from '../config/mainnet';
 import { getViemClient } from '../modules/sources/viem-client';
 import { multicallViem } from '../modules/web3/multicaller-viem';
@@ -50,7 +51,7 @@ interface SwapData {
     tokenOut: string;
     amount: string; // This is amountIn scaled (for backward compatibility)
     amountIn: string; // Raw amount in
-    amountOut: string; // Raw amount out  
+    amountOut: string; // Raw amount out
     amountInScaled?: string; // Scaled amount in
     amountOutScaled?: string; // Scaled amount out
     poolId?: string;
@@ -256,11 +257,11 @@ class SwapDataFetcher {
         for (const swap of swaps) {
             const inDecimals = this.tokenDecimals.get(swap.tokenIn) || 18;
             const outDecimals = this.tokenDecimals.get(swap.tokenOut) || 18;
-            
+
             // Scale both amounts
             swap.amountInScaled = formatUnits(BigInt(swap.amountIn), inDecimals);
             swap.amountOutScaled = formatUnits(BigInt(swap.amountOut), outDecimals);
-            
+
             // Keep 'amount' as scaled amountIn for backward compatibility
             swap.amount = swap.amountInScaled;
         }
@@ -269,8 +270,14 @@ class SwapDataFetcher {
 
 // 2. SOR Profiler - Tests SOR with provided swaps
 class SorProfiler {
-    async profileSwaps(swaps: SwapData[], opts: { heap?: boolean } = {}): Promise<ProfileResult> {
-        console.log(`\n🔄 Profiling SOR with ${swaps.length} swaps... (heap=${!!opts.heap})`);
+    async profileSwaps(swaps: SwapData[], opts: { heap?: boolean; algorithm?: PathGraphVersion | 'all' } = {}): Promise<ProfileResult> {
+        const algorithm = opts.algorithm || 'original';
+        console.log(`\n🔄 Profiling SOR with ${swaps.length} swaps... (heap=${!!opts.heap}, algorithm=${algorithm})`);
+        
+        // If comparing all algorithms
+        if (algorithm === 'all') {
+            return await this.compareAllAlgorithms(swaps, opts);
+        }
 
         const session = new Session();
         session.connect();
@@ -294,8 +301,8 @@ class SorProfiler {
         await post('Profiler.start');
         const startTime = performance.now();
 
-        console.log(`   Creating SorService instance...`);
-        const sor = new SorService();
+        console.log(`   Creating SorService instance with ${algorithm} algorithm...`);
+        const sor = new SorService(algorithm as PathGraphVersion);
 
         let successful = 0;
         let failed = 0;
@@ -311,14 +318,14 @@ class SorProfiler {
                     chain: 'MAINNET',
                 });
                 successful++;
-                
+
                 // Compare SOR result with actual swap output
                 if (sorResult.returnAmount && swap.amountOutScaled) {
                     const sorAmount = parseFloat(sorResult.returnAmount);
                     const actualAmount = parseFloat(swap.amountOutScaled);
                     const deviation = sorAmount - actualAmount;
                     const deviationPercent = actualAmount !== 0 ? (deviation / actualAmount) * 100 : 0;
-                    
+
                     comparisons.push({
                         swap,
                         sorReturnAmount: sorResult.returnAmount,
@@ -327,7 +334,7 @@ class SorProfiler {
                         deviationPercent,
                     });
                 }
-                
+
                 if (successful % 10 === 0) process.stdout.write('.');
             } catch {
                 failed++;
@@ -359,7 +366,7 @@ class SorProfiler {
 
         // --- Analyze comparisons ---
         const biggestDeviations = this.analyzeComparisons(comparisons);
-        
+
         // --- Analyze CPU profile ---
         if (profile) {
             const analysis = this.analyzeProfile(profile);
@@ -376,37 +383,153 @@ class SorProfiler {
             };
         }
 
-        return { 
-            successful, 
-            failed, 
-            duration, 
+        return {
+            successful,
+            failed,
+            duration,
             avgPerSwap: duration / swaps.length,
             comparisons,
             biggestDeviations,
         };
     }
+
+    private async compareAllAlgorithms(swaps: SwapData[], opts: { heap?: boolean }): Promise<ProfileResult> {
+        const algorithms: PathGraphVersion[] = ['original', 'beamOptimisation', 'bfsOptimisation'];
+        const results: Record<string, { duration: number; successful: number; failed: number; comparisons: SwapComparison[] }> = {};
+        
+        console.log('\n🎬 Comparing all path finding algorithms...');
+        console.log('='.repeat(60));
+        
+        for (const algo of algorithms) {
+            console.log(`\n\n🔄 Testing ${algo} algorithm...`);
+            const startTime = performance.now();
+            const sor = new SorService(algo);
+            
+            let successful = 0;
+            let failed = 0;
+            const comparisons: SwapComparison[] = [];
+            
+            for (const swap of swaps) {
+                try {
+                    const sorResult = await sor.getSorSwapPaths({
+                        tokenIn: swap.tokenIn,
+                        tokenOut: swap.tokenOut,
+                        swapAmount: swap.amount,
+                        swapType: 'EXACT_IN',
+                        chain: 'MAINNET',
+                    });
+                    successful++;
+                    
+                    if (sorResult.returnAmount && swap.amountOutScaled) {
+                        const sorAmount = parseFloat(sorResult.returnAmount);
+                        const actualAmount = parseFloat(swap.amountOutScaled);
+                        comparisons.push({
+                            swap,
+                            sorReturnAmount: sorResult.returnAmount,
+                            actualAmountOut: swap.amountOutScaled,
+                            deviation: sorAmount - actualAmount,
+                            deviationPercent: actualAmount !== 0 ? ((sorAmount - actualAmount) / actualAmount) * 100 : 0,
+                        });
+                    }
+                    
+                    if (successful % 10 === 0) process.stdout.write('.');
+                } catch {
+                    failed++;
+                }
+            }
+            
+            const duration = performance.now() - startTime;
+            results[algo] = { duration, successful, failed, comparisons };
+            
+            console.log('');
+            console.log(`   ✅ ${algo}: ${successful}/${swaps.length} successful in ${duration.toFixed(2)}ms`);
+        }
+        
+        // Compare results
+        this.compareAlgorithmResults(results, swaps.length);
+        
+        // Return results for the fastest algorithm
+        const fastest = Object.entries(results).sort((a, b) => a[1].duration - b[1].duration)[0];
+        return {
+            successful: fastest[1].successful,
+            failed: fastest[1].failed,
+            duration: fastest[1].duration,
+            avgPerSwap: fastest[1].duration / swaps.length,
+            comparisons: fastest[1].comparisons,
+            biggestDeviations: this.analyzeComparisons(fastest[1].comparisons),
+        };
+    }
+    
+    private compareAlgorithmResults(results: Record<string, any>, totalSwaps: number): void {
+        console.log('\n\n📊 Algorithm Comparison Summary:');
+        console.log('='.repeat(60));
+        
+        // Sort by duration
+        const sorted = Object.entries(results).sort((a, b) => a[1].duration - b[1].duration);
+        
+        console.log('\n⏱️  Performance Ranking:');
+        sorted.forEach(([algo, data], index) => {
+            const speedup = index > 0 ? ((sorted[0][1].duration / data.duration - 1) * 100).toFixed(1) : '0';
+            console.log(`   ${index + 1}. ${algo}:`);
+            console.log(`      Duration: ${data.duration.toFixed(2)}ms`);
+            console.log(`      Avg/swap: ${(data.duration / totalSwaps).toFixed(2)}ms`);
+            console.log(`      Success rate: ${((data.successful / totalSwaps) * 100).toFixed(1)}%`);
+            if (index > 0) {
+                console.log(`      Speedup vs fastest: ${speedup}%`);
+            }
+        });
+        
+        // Compare output quality
+        console.log('\n🎯 Output Quality Comparison:');
+        for (const [algo, data] of Object.entries(results)) {
+            if (data.comparisons.length > 0) {
+                const avgDeviation = data.comparisons.reduce((sum: number, c: SwapComparison) => 
+                    sum + Math.abs(c.deviationPercent), 0) / data.comparisons.length;
+                const betterCount = data.comparisons.filter((c: SwapComparison) => c.deviation > 0).length;
+                
+                console.log(`   ${algo}:`);
+                console.log(`      Avg deviation: ${avgDeviation.toFixed(2)}%`);
+                console.log(`      Found better paths: ${betterCount}/${data.comparisons.length}`);
+            }
+        }
+        
+        // Check if all algorithms return same results
+        const returnAmounts = Object.entries(results).map(([algo, data]) => {
+            return data.comparisons.map((c: SwapComparison) => c.sorReturnAmount);
+        });
+        
+        if (returnAmounts.length > 1) {
+            let allSame = true;
+            for (let i = 0; i < returnAmounts[0].length; i++) {
+                const amounts = returnAmounts.map(amounts => amounts[i]);
+                if (amounts.some(a => a !== amounts[0])) {
+                    allSame = false;
+                    break;
+                }
+            }
+            console.log(`\n🔍 Result Consistency: ${allSame ? '✅ All algorithms return same amounts' : '⚠️  Algorithms return different amounts'}`);
+        }
+    }
     
     private analyzeComparisons(comparisons: SwapComparison[]): SwapComparison[] {
         if (comparisons.length === 0) return [];
-        
+
         // Sort by absolute deviation percentage
-        const sorted = [...comparisons].sort((a, b) => 
-            Math.abs(b.deviationPercent) - Math.abs(a.deviationPercent)
-        );
-        
+        const sorted = [...comparisons].sort((a, b) => Math.abs(b.deviationPercent) - Math.abs(a.deviationPercent));
+
         // Log summary statistics
         const avgDeviation = comparisons.reduce((sum, c) => sum + Math.abs(c.deviationPercent), 0) / comparisons.length;
-        const betterCount = comparisons.filter(c => c.deviation > 0).length;
-        const worseCount = comparisons.filter(c => c.deviation < 0).length;
-        const exactCount = comparisons.filter(c => Math.abs(c.deviation) < 0.000001).length;
-        
+        const betterCount = comparisons.filter((c) => c.deviation > 0).length;
+        const worseCount = comparisons.filter((c) => c.deviation < 0).length;
+        const exactCount = comparisons.filter((c) => Math.abs(c.deviation) < 0.000001).length;
+
         console.log('\n📊 SOR vs Actual Comparison:');
         console.log(`   Total comparisons: ${comparisons.length}`);
         console.log(`   Average deviation: ${avgDeviation.toFixed(2)}%`);
-        console.log(`   SOR better: ${betterCount} (${(betterCount / comparisons.length * 100).toFixed(1)}%)`);
-        console.log(`   SOR worse: ${worseCount} (${(worseCount / comparisons.length * 100).toFixed(1)}%)`);
+        console.log(`   SOR better: ${betterCount} (${((betterCount / comparisons.length) * 100).toFixed(1)}%)`);
+        console.log(`   SOR worse: ${worseCount} (${((worseCount / comparisons.length) * 100).toFixed(1)}%)`);
         console.log(`   Exact match: ${exactCount}`);
-        
+
         // Return top 10 biggest deviations
         return sorted.slice(0, 10);
     }
@@ -472,18 +595,22 @@ class SorProfiler {
         console.log(`   Failed: ${failed}`);
         console.log(`   Total time: ${duration.toFixed(2)}ms`);
         console.log(`   Avg per swap: ${(duration / total).toFixed(2)}ms`);
-        
+
         // Print biggest deviations
         if (biggestDeviations && biggestDeviations.length > 0) {
             console.log(`\n🎯 Biggest Deviations (SOR vs Actual):`);
             for (let i = 0; i < Math.min(5, biggestDeviations.length); i++) {
                 const comp = biggestDeviations[i];
                 const sign = comp.deviation > 0 ? '+' : '';
-                console.log(`   ${i + 1}. ${comp.swap.tokenIn.slice(0, 6)}...${comp.swap.tokenIn.slice(-4)} → ${comp.swap.tokenOut.slice(0, 6)}...${comp.swap.tokenOut.slice(-4)}`);
+                console.log(
+                    `   ${i + 1}. ${comp.swap.tokenIn.slice(0, 6)}...${comp.swap.tokenIn.slice(-4)} → ${comp.swap.tokenOut.slice(0, 6)}...${comp.swap.tokenOut.slice(-4)}`,
+                );
                 console.log(`      Amount In: ${parseFloat(comp.swap.amount).toFixed(4)}`);
                 console.log(`      SOR Output: ${parseFloat(comp.sorReturnAmount).toFixed(4)}`);
                 console.log(`      Actual Output: ${parseFloat(comp.actualAmountOut).toFixed(4)}`);
-                console.log(`      Deviation: ${sign}${comp.deviation.toFixed(6)} (${sign}${comp.deviationPercent.toFixed(2)}%)`);
+                console.log(
+                    `      Deviation: ${sign}${comp.deviation.toFixed(6)} (${sign}${comp.deviationPercent.toFixed(2)}%)`,
+                );
                 console.log(`      ${comp.deviation > 0 ? '✅ SOR found better path' : '⚠️  SOR predicted worse'}`);
             }
         }
@@ -548,7 +675,10 @@ class CLI {
         }
 
         // Profile the swaps
-        await this.profiler.profileSwaps(swaps);
+        await this.profiler.profileSwaps(swaps, { 
+            heap: options.heap,
+            algorithm: options.algorithm 
+        });
     }
 
     private parseArgs(args: string[]): any {
@@ -558,6 +688,8 @@ class CLI {
             count: CONFIG.defaults.swapCount,
             file: null,
             singleSwap: null,
+            heap: false,
+            algorithm: 'original' as PathGraphVersion | 'all',
         };
 
         // Parse fetch-only mode
@@ -573,6 +705,22 @@ class CLI {
         const countIndex = args.indexOf('--count');
         if (countIndex !== -1 && args[countIndex + 1]) {
             options.count = parseInt(args[countIndex + 1]) || CONFIG.defaults.swapCount;
+        }
+        
+        // Parse heap
+        if (args.includes('--heap')) {
+            options.heap = true;
+        }
+        
+        // Parse algorithm
+        const algoIndex = args.indexOf('--algorithm');
+        if (algoIndex !== -1 && args[algoIndex + 1]) {
+            const algo = args[algoIndex + 1];
+            if (algo === 'all' || algo === 'original' || algo === 'beam' || algo === 'bfs') {
+                options.algorithm = algo === 'beam' ? 'beamOptimisation' : 
+                                  algo === 'bfs' ? 'bfsOptimisation' : 
+                                  algo;
+            }
         }
 
         // Parse file
@@ -621,6 +769,8 @@ Options:
   --file <path>                Use swaps from specified file
   --swap <in,out,amount>       Test single swap (e.g., --swap 0xC02aa...,0x6B17...,1.5)
   --count <n>                  Number of swaps to fetch (default: ${CONFIG.defaults.swapCount})
+  --algorithm <type>           Path finding algorithm: 'original', 'beam', 'bfs', or 'all' to compare (default: original)
+  --heap                       Enable heap profiling
   --help                       Show this help
 
 Examples:
@@ -629,6 +779,12 @@ Examples:
 
   # Test with previously saved swaps
   npx tsx scripts/profile-sor.ts --file profiles/real-swaps/latest-swaps.json
+  
+  # Compare all path finding algorithms
+  npx tsx scripts/profile-sor.ts --algorithm all
+  
+  # Use specific algorithm with heap profiling
+  npx tsx scripts/profile-sor.ts --algorithm beam --heap
 
   # Test single swap
   npx tsx scripts/profile-sor.ts --swap 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2,0x6B175474E89094C44Da98b954EedeAC495271d0F,1.5


### PR DESCRIPTION
Why this is faster

- No recursion or repeated array copies in token-path search; we push/pop on a single shared path and visited set.
- Incremental constraint tracking avoids O(len(path)) scans on each step.
- Early stop based on approxPathsToReturn (as your comments suggest) keeps the search bounded.
- Beam search on ranks uses cached per-edge limits to prune aggressively before running the expensive full-path limit calculation.
- At most approxPathsToReturn full getLimitAmountSwapForPath evaluations per token path, instead of exploring all rank combinations.