### PR TITLE
Sor fix unwrap rates internally

### DIFF
--- a/.changeset/stupid-moose-develop.md
+++ b/.changeset/stupid-moose-develop.md
@@ -1,0 +1,5 @@
+---
+'backend': patch
+---
+
+SOR - Fix unwrapRates scaling

--- a/modules/sor/utils/data.ts
+++ b/modules/sor/utils/data.ts
@@ -1,5 +1,5 @@
 import { Cache } from 'memory-cache';
-import { Address, parseUnits } from 'viem';
+import { Address, parseEther, parseUnits } from 'viem';
 import { Chain, PrismaPoolType, PrismaToken } from '@prisma/client';
 
 import { prisma } from '../../../prisma/prisma-client';
@@ -253,7 +253,6 @@ export async function getBufferPoolsFromDBPools(pools: SORDbPool[], chain: Chain
                 // check if underlying token exists in the database
                 const underlyingToken = tokensMap[poolToken.token.underlyingTokenAddress];
                 if (underlyingToken) {
-                    const unwrapRateDecimals = 18 - poolToken.token.decimals + underlyingToken.decimals;
                     bufferPools.push({
                         poolId: pool.id,
                         address: poolToken.address.toLowerCase() as Address,
@@ -269,7 +268,7 @@ export async function getBufferPoolsFromDBPools(pools: SORDbPool[], chain: Chain
                             balance: parseUnits(poolToken.token.bufferBalanceUnderlying, underlyingToken.decimals),
                         },
                         poolType: 'Buffer',
-                        unwrapRate: parseUnits(poolToken.token.unwrapRate, unwrapRateDecimals),
+                        unwrapRate: parseEther(poolToken.token.unwrapRate), // the way we store rates already takes into account main/underlying decimals differences
                         maxWithdraw: parseUnits(poolToken.token.maxWithdraw, poolToken.token.decimals),
                         maxDeposit: parseUnits(poolToken.token.maxDeposit, poolToken.token.decimals),
                     });


### PR DESCRIPTION
Context
- unwrapRates scaling is now reflected on the float point representation within the DB and no longer needs to be applied in the SOR side as well

Example for ghUSDC on SONIC:

previous implementation:
- main token decimals -> 18
- underlying token decimals -> 6
- rate within DB -> 1.040198652125
- unwrapRate decimals -> 12 (i.e. diff between main and underlying decimals)
- rate within SOR -> 1040198652125

current implementation:
- main token decimals -> 18
- underlying token decimals -> 6
- rate within DB -> 0.000001040198652125
- unwrapRate decimals -> 18 (i.e. always 18 because diff between main and underlying is already factored in)
- rate within SOR -> 1040198652125

