### PR TITLE
Sor fix buffer scaling (temporary)

### DIFF
--- a/.changeset/quick-wasps-draw.md
+++ b/.changeset/quick-wasps-draw.md
@@ -1,0 +1,5 @@
+---
+'backend': patch
+---
+
+SOR - Fix buffer maths to handle rates as 1e18

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "WebFetch(domain:github.com)"
-    ],
-    "deny": [],
-    "ask": []
-  }
-}

--- a/modules/sor/lib/poolsV3/buffer/bufferPool.ts
+++ b/modules/sor/lib/poolsV3/buffer/bufferPool.ts
@@ -19,6 +19,7 @@ export class BufferPool implements BasePoolMethodsV3 {
     public readonly maxWithdraw: bigint;
 
     private readonly tokenMap: Map<string, BasePoolToken>;
+    private readonly decimalDiff: number; // mainDecimals - underlyingDecimals
 
     private vault: Vault;
     private poolState: BufferState;
@@ -74,9 +75,30 @@ export class BufferPool implements BasePoolMethodsV3 {
         this.maxWithdraw = maxWithdraw;
         this.tokens = [mainToken, underlyingToken];
         this.tokenMap = new Map(this.tokens.map((token) => [token.token.address, token]));
+        this.decimalDiff = mainToken.token.decimals - underlyingToken.token.decimals;
 
         this.vault = new Vault();
         this.poolState = this.getPoolState();
+    }
+
+    /**
+     * Scales an amount from main token decimals to underlying token decimals.
+     * Used after rate multiplication (mulDownFixed) which preserves the input's decimal scale.
+     */
+    private toUnderlyingDecimals(amount: bigint): bigint {
+        if (this.decimalDiff > 0) return amount / 10n ** BigInt(this.decimalDiff);
+        if (this.decimalDiff < 0) return amount * 10n ** BigInt(-this.decimalDiff);
+        return amount;
+    }
+
+    /**
+     * Scales an amount from underlying token decimals to main token decimals.
+     * Used after rate division (divDownFixed) which preserves the input's decimal scale.
+     */
+    private toMainDecimals(amount: bigint): bigint {
+        if (this.decimalDiff > 0) return amount * 10n ** BigInt(this.decimalDiff);
+        if (this.decimalDiff < 0) return amount / 10n ** BigInt(-this.decimalDiff);
+        return amount;
     }
 
     public getNormalizedLiquidity(tokenIn: Token, tokenOut: Token): bigint {
@@ -93,11 +115,13 @@ export class BufferPool implements BasePoolMethodsV3 {
             // givenIn
             if (underlyingTokenAmount.token.isSameAddress(tIn.token.address)) {
                 // wrap - respective to amount in, which is underlying
-                const bufferWrapLimit = MathSol.mulDownFixed(mainTokenAmount.amount, this.rate); //  in terms of underlying
+                const mainAsUnderlying = this.toUnderlyingDecimals(
+                    MathSol.mulDownFixed(mainTokenAmount.amount, this.rate),
+                );
+                const bufferWrapLimit = mainAsUnderlying; // in terms of underlying
                 const lendingProtocolWrapLimit = this.maxDeposit;
                 const wrapRequiredToRebalance =
-                    (MathSol.mulDownFixed(mainTokenAmount.amount, this.rate) + underlyingTokenAmount.amount) / 2n -
-                    underlyingTokenAmount.amount; // in terms of underlying
+                    (mainAsUnderlying + underlyingTokenAmount.amount) / 2n - underlyingTokenAmount.amount; // in terms of underlying
                 const wrapLimit =
                     wrapRequiredToRebalance > lendingProtocolWrapLimit
                         ? bufferWrapLimit
@@ -105,11 +129,14 @@ export class BufferPool implements BasePoolMethodsV3 {
                 return wrapLimit;
             } else {
                 // unwrap - respective to amount in, which is main
-                const bufferUnwrapLimit = MathSol.divDownFixed(underlyingTokenAmount.amount, this.rate); // in terms of main
-                const lendingProtocolUnwrapLimit = MathSol.divDownFixed(this.maxWithdraw, this.rate); // in terms of main;
+                const underlyingAsMain = this.toMainDecimals(
+                    MathSol.divDownFixed(underlyingTokenAmount.amount, this.rate),
+                );
+                const bufferUnwrapLimit = underlyingAsMain; // in terms of main
+                const maxWithdrawAsMain = this.toMainDecimals(MathSol.divDownFixed(this.maxWithdraw, this.rate));
+                const lendingProtocolUnwrapLimit = maxWithdrawAsMain; // in terms of main
                 const unwrapRequiredToRebalance =
-                    (MathSol.divDownFixed(underlyingTokenAmount.amount, this.rate) + mainTokenAmount.amount) / 2n -
-                    mainTokenAmount.amount; // in terms of main
+                    (underlyingAsMain + mainTokenAmount.amount) / 2n - mainTokenAmount.amount; // in terms of main
                 const unwrapLimit =
                     unwrapRequiredToRebalance > lendingProtocolUnwrapLimit
                         ? bufferUnwrapLimit
@@ -120,11 +147,14 @@ export class BufferPool implements BasePoolMethodsV3 {
             // givenOut
             if (underlyingTokenAmount.token.isSameAddress(tIn.token.address)) {
                 // wrap - respective to amount out, which is main
+                const underlyingAsMain = this.toMainDecimals(
+                    MathSol.divDownFixed(underlyingTokenAmount.amount, this.rate),
+                );
                 const bufferWrapLimit = mainTokenAmount.amount; // in terms of main
-                const lendingProtocolWrapLimit = MathSol.divDownFixed(this.maxDeposit, this.rate); // in terms of main;
+                const maxDepositAsMain = this.toMainDecimals(MathSol.divDownFixed(this.maxDeposit, this.rate));
+                const lendingProtocolWrapLimit = maxDepositAsMain; // in terms of main
                 const wrapRequiredToRebalance =
-                    mainTokenAmount.amount -
-                    (MathSol.divDownFixed(underlyingTokenAmount.amount, this.rate) + mainTokenAmount.amount) / 2n; // in terms of main
+                    mainTokenAmount.amount - (underlyingAsMain + mainTokenAmount.amount) / 2n; // in terms of main
                 const wrapLimit =
                     wrapRequiredToRebalance > lendingProtocolWrapLimit
                         ? bufferWrapLimit
@@ -132,11 +162,13 @@ export class BufferPool implements BasePoolMethodsV3 {
                 return wrapLimit;
             } else {
                 // unwrap - respective to amount out, which is underlying
+                const mainAsUnderlying = this.toUnderlyingDecimals(
+                    MathSol.mulDownFixed(mainTokenAmount.amount, this.rate),
+                );
                 const bufferUnwrapLimit = underlyingTokenAmount.amount; // in terms of underlying
                 const lendingProtocolUnwrapLimit = this.maxWithdraw;
                 const unwrapRequiredToRebalance =
-                    underlyingTokenAmount.amount -
-                    (underlyingTokenAmount.amount + MathSol.mulDownFixed(mainTokenAmount.amount, this.rate)) / 2n; // in terms of underlying
+                    underlyingTokenAmount.amount - (underlyingTokenAmount.amount + mainAsUnderlying) / 2n; // in terms of underlying
                 const unwrapLimit =
                     unwrapRequiredToRebalance > lendingProtocolUnwrapLimit
                         ? bufferUnwrapLimit
@@ -159,13 +191,19 @@ export class BufferPool implements BasePoolMethodsV3 {
             this.poolState,
         );
 
-        return TokenAmount.fromRawAmount(tOut.token, calculatedAmount);
+        // Vault rate math preserves input decimal scale, so we need to scale the result
+        // to the output token's decimals
+        const isUnwrap = tIn.token.isSameAddress(this.tokens[0].token.address);
+        const scaledAmount = isUnwrap
+            ? this.toUnderlyingDecimals(calculatedAmount) // main→underlying
+            : this.toMainDecimals(calculatedAmount); // underlying→main
+
+        return TokenAmount.fromRawAmount(tOut.token, scaledAmount);
     }
 
     public swapGivenOut(tokenIn: Token, tokenOut: Token, swapAmount: TokenAmount): TokenAmount {
         const { tIn, tOut } = this.getPoolTokens(tokenIn, tokenOut);
 
-        // swap
         const calculatedAmount = this.vault.swap(
             {
                 amountRaw: swapAmount.amount,
@@ -175,7 +213,15 @@ export class BufferPool implements BasePoolMethodsV3 {
             },
             this.poolState,
         );
-        return TokenAmount.fromRawAmount(tIn.token, calculatedAmount);
+
+        // Vault rate math preserves input (amountOut) decimal scale, so we need to
+        // scale the result to the input token's decimals
+        const isUnwrap = tIn.token.isSameAddress(this.tokens[0].token.address);
+        const scaledAmount = isUnwrap
+            ? this.toMainDecimals(calculatedAmount) // underlyingDec→mainDec
+            : this.toUnderlyingDecimals(calculatedAmount); // mainDec→underlyingDec
+
+        return TokenAmount.fromRawAmount(tIn.token, scaledAmount);
     }
 
     public getPoolState(): BufferState {
@@ -219,10 +265,14 @@ export class BufferPool implements BasePoolMethodsV3 {
         const underlyingTokenAmount = this.tokens[1];
 
         if (tIn.token.isSameAddress(underlyingTokenAmount.token.address)) {
-            const bufferWrapLimit = MathSol.mulDownFixed(mainTokenAmount.amount, this.rate);
+            // wrap: swapAmount is in underlying decimals, so convert limit to underlying decimals
+            const bufferWrapLimit = this.toUnderlyingDecimals(MathSol.mulDownFixed(mainTokenAmount.amount, this.rate));
             return swapAmount.amount > bufferWrapLimit;
         } else {
-            const bufferUnwrapLimit = MathSol.divDownFixed(underlyingTokenAmount.amount, this.rate);
+            // unwrap: swapAmount is in main decimals, so convert limit to main decimals
+            const bufferUnwrapLimit = this.toMainDecimals(
+                MathSol.divDownFixed(underlyingTokenAmount.amount, this.rate),
+            );
             return swapAmount.amount > bufferUnwrapLimit;
         }
     }

--- a/modules/sor/sor-debug.test.ts
+++ b/modules/sor/sor-debug.test.ts
@@ -1,7 +1,6 @@
 // bun vitest sor-debug.test.ts
-import { Chain } from '@prisma/client';
-import { initRequestScopedContext, setRequestScopedContextValue } from '../context/request-scoped-context';
-import { chainIdToChain } from '../network/chain-id-to-chain';
+import { GqlChain } from '../../apps/api/gql/generated-schema';
+import { chainToChainId } from '../network/chain-id-to-chain';
 import { sorService } from './sor.service';
 import { Address, Swap, SwapInput, SwapKind } from '@balancer/sdk';
 import { formatUnits } from 'viem';
@@ -9,11 +8,9 @@ import { formatUnits } from 'viem';
 describe('sor debugging', () => {
     it('sor v2', async () => {
         const useProtocolVersion = 2;
-        const chain = Chain.BASE;
+        const chain: GqlChain = 'BASE';
 
-        const chainId = Object.keys(chainIdToChain).find((key) => chainIdToChain[key] === chain) as string;
-        initRequestScopedContext();
-        setRequestScopedContextValue('chainId', chainId);
+        const chainId = chainToChainId[chain];
 
         // only do once before starting to debug
         // bun task sor-sync-v2 {chainId}
@@ -34,10 +31,10 @@ describe('sor debugging', () => {
             //     slippagePercentage: '0.1',
             // },
             poolIds: [
-                        "0x2db50a0e0310723ef0c2a165cb9a9f80d772ba2f00020000000000000000000d",
-                        "0x6fbfcf88db1aada31f34215b2a1df7fafb4883e900000000000000000000000c",
-                        "0x8f360baf899845441eccdc46525e26bb8860752a0002000000000000000001cd"
-                    ],
+                '0x2db50a0e0310723ef0c2a165cb9a9f80d772ba2f00020000000000000000000d',
+                '0x6fbfcf88db1aada31f34215b2a1df7fafb4883e900000000000000000000000c',
+                '0x8f360baf899845441eccdc46525e26bb8860752a0002000000000000000001cd',
+            ],
         });
 
         console.log('protocol version', swaps.protocolVersion);
@@ -77,27 +74,29 @@ describe('sor debugging', () => {
         expect(ratio).toBeCloseTo(1, 3);
     }, 5000000);
 
-    it('sor v3', async () => {
+    it.only('sor v3', async () => {
         const useProtocolVersion = 3;
-        const chain = Chain.SONIC;
+        const chain: GqlChain = 'MAINNET';
 
-        const chainId = Object.keys(chainIdToChain).find((key) => chainIdToChain[key] === chain) as string;
-        initRequestScopedContext();
-        setRequestScopedContextValue('chainId', chainId);
+        const chainId = chainToChainId[chain];
+
         // only do once before starting to debug
         // bun task sor-sync-v3 {chainId}
 
+        const tokenIn = '0xc86168d2424d28942ee0866f043c1206bc9e4900'; // jUSD
+        const tokenOut = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'; // USDC
+        const poolId = '0xb20fa48d028b5ba6de33e09c72643c1fe92f8fcd';
         const swapType = 'EXACT_IN';
         const swapKind: SwapKind = SwapKind.GivenIn;
 
         const swaps = await sorService.getSorSwapPaths({
             chain,
-            tokenIn: '0x0c4e186eae8acaa7f7de1315d5ad174be39ec987', // smsUSD
-            tokenOut: '0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38', // USDC
+            tokenIn,
+            tokenOut,
             swapType,
-            swapAmount: '1000000',
+            swapAmount: '1',
             useProtocolVersion,
-            poolIds: ['0x944d4ae892de4bfd38742cc8295d6d5164c5593c'],
+            poolIds: [poolId],
         });
 
         swaps.paths.forEach((path, i) => {

--- a/modules/sor/sor.service.ts
+++ b/modules/sor/sor.service.ts
@@ -19,6 +19,7 @@ import {
 import { PathWithAmount } from './lib/path';
 import { getInputAmount, getOutputAmount } from './lib/utils';
 import { PathGraphTraversalConfig } from './lib/pathGraph/pathGraphTypes';
+import { Chain } from '@prisma/client';
 
 const DEFAULT_MAX_DEPTH = 4;
 
@@ -27,12 +28,14 @@ export class SorService {
         const tokenIn = args.tokenIn.toLowerCase();
         const tokenOut = args.tokenOut.toLowerCase();
 
+        const chain = args.chain as Chain;
+
         // early returns for invalid requests
-        if (!isValidSwapRequest(tokenIn, tokenOut, args.swapAmount, args.chain!)) {
-            return swapPathsZeroResponse(args.tokenIn, args.tokenOut, args.chain);
+        if (!isValidSwapRequest(tokenIn, tokenOut, args.swapAmount, chain)) {
+            return swapPathsZeroResponse(args.tokenIn, args.tokenOut, chain);
         }
-        if (!(await validateTokens(tokenIn, tokenOut, args.chain))) {
-            return swapPathsZeroResponse(args.tokenIn, args.tokenOut, args.chain);
+        if (!(await validateTokens(tokenIn, tokenOut, chain))) {
+            return swapPathsZeroResponse(args.tokenIn, args.tokenOut, chain);
         }
 
         // map SOR Service inputs to SOR inputs
@@ -57,7 +60,7 @@ export class SorService {
         }
 
         // map SOR output to SOR Service output
-        const mappedPaths = await mapToSorSwapPaths(paths, args.swapType, args.chain, protocolVersion);
+        const mappedPaths = await mapToSorSwapPaths(paths, args.swapType, chain, protocolVersion);
 
         return mappedPaths;
     }


### PR DESCRIPTION
Main changes:

- This PR fixes getLimitAmountSwap scaling up/down within buffer pool
- Applies a temporary fix to the buffer math that should later be replaced with a fix within balancer-maths. When balancer-maths is fixed, this temporary fix within buffer pool math should be reverted.

Minor changes:
- Stopped tracking .claude folder since it's a local config -> suggestion is to add it to global gitignore
