### PR TITLE
APR - Fix wnLOAZND APY

### DIFF
--- a/.changeset/many-pillows-explode.md
+++ b/.changeset/many-pillows-explode.md
@@ -1,0 +1,5 @@
+---
+'backend': patch
+---
+
+APR - Fix wnLOAZND APY

--- a/config/monad.ts
+++ b/config/monad.ts
@@ -126,6 +126,15 @@ export default <NetworkData>{
                     name: 'wnloAZND',
                     url: 'https://app.neverland.money/api/pool-apy',
                     scale: 100,
+                    convert: async (baseAPY: number) => {
+                        const res = await (
+                            await fetch('https://app.neverland.money/api/pool-apy')
+                        ).json();
+                        const externalAPY =
+                            (res as any).reserves['0x9c82eb49b51f7dc61e22ff347931ca32adc6cd90']
+                                .supply.externalAPY / 100;
+                        return baseAPY + externalAPY;
+                    },
                     extractors: [
                         {
                             type: 'path',


### PR DESCRIPTION
APY should consider both `baseAPY` and `externalAPY` for neverland tokens.

Fix applied to `wnLOAZND` to keep changes minimal, but worth double checking if replicating the fix to all neverland tokens is the expected long term approach here.

Ps: not currently an issue because all other neverland tokens have `externalAPY` as zero.