### PR TITLE
Use TokenLogic for Aave v4 Core APRs

### DIFF
--- a/apps/env.ts
+++ b/apps/env.ts
@@ -70,6 +70,10 @@ export const schema = {
         type: String,
         optional: true,
     },
+    TOKENLOGIC_API_KEY: {
+        type: String,
+        optional: true,
+    },
     FUUL_HYPURR_API_KEY: {
         type: String,
         optional: true,

--- a/config/avalanche.ts
+++ b/config/avalanche.ts
@@ -239,6 +239,28 @@ export default <NetworkData>{
                         },
                     ],
                 },
+                {
+                    url: 'https://api.tokenlogic.xyz/v1/aave/reserves/main-avalanche-core-v4/0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e/latest',
+                    headers: { Authorization: `Bearer ${env.TOKENLOGIC_API_KEY}` },
+                    extractors: [
+                        {
+                            type: 'path',
+                            token: '0x01d7f7b7ce2123192fecc20bd1caf3e4d9e4c10d',
+                            path: '$.data[-1:].supply_apy',
+                        },
+                    ],
+                },
+                {
+                    url: 'https://api.tokenlogic.xyz/v1/aave/reserves/main-avalanche-core-v4/0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7/latest',
+                    headers: { Authorization: `Bearer ${env.TOKENLOGIC_API_KEY}` },
+                    extractors: [
+                        {
+                            type: 'path',
+                            token: '0x2e4ba06ff97e10d09fa4f5a270e97301eae729a9',
+                            path: '$.data[-1:].supply_apy',
+                        },
+                    ],
+                },
             ],
         },
     },

--- a/config/mainnet.ts
+++ b/config/mainnet.ts
@@ -237,46 +237,46 @@ export default <NetworkData>{
                     ],
                 },
                 {
-                    url: 'https://yields.llama.fi/chart/4ac1a968-68ab-4da8-87e3-8f1e15e3dae2',
-                    scale: 100,
+                    url: 'https://api.tokenlogic.xyz/v1/aave/reserves/main-ethereum-core-v4/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48/latest',
+                    headers: { Authorization: `Bearer ${env.TOKENLOGIC_API_KEY}` },
                     extractors: [
                         {
                             type: 'path',
                             token: '0x531e90a2376902de8915789fcc1075e3b0c153e7',
-                            path: '$.data[-1:].apyBase',
+                            path: '$.data[-1:].supply_apy',
                         },
                     ],
                 },
                 {
-                    url: 'https://yields.llama.fi/chart/517f3a7a-a3b0-4af9-be8e-bcb0fb549744',
-                    scale: 100,
+                    url: 'https://api.tokenlogic.xyz/v1/aave/reserves/main-ethereum-core-v4/0xdac17f958d2ee523a2206206994597c13d831ec7/latest',
+                    headers: { Authorization: `Bearer ${env.TOKENLOGIC_API_KEY}` },
                     extractors: [
                         {
                             type: 'path',
                             token: '0x5ec44a70f309854fe04d495cfe1b5da63dd1cc73',
-                            path: '$.data[-1:].apyBase',
+                            path: '$.data[-1:].supply_apy',
                         },
                     ],
                 },
                 {
-                    url: 'https://yields.llama.fi/chart/71411cad-9bda-49a9-baeb-670f03eee045',
-                    scale: 100,
+                    url: 'https://api.tokenlogic.xyz/v1/aave/reserves/main-ethereum-core-v4/0x40d16fc0246ad3160ccc09b8d0d3a2cd28ae6c2f/latest',
+                    headers: { Authorization: `Bearer ${env.TOKENLOGIC_API_KEY}` },
                     extractors: [
                         {
                             type: 'path',
                             token: '0x58c14a5e061c9bc6926c5b853445290f296c2f7b',
-                            path: '$.data[-1:].apyBase',
+                            path: '$.data[-1:].supply_apy',
                         },
                     ],
                 },
                 {
-                    url: 'https://yields.llama.fi/chart/411707d7-0293-4ad3-982d-72125e1f5de7',
-                    scale: 100,
+                    url: 'https://api.tokenlogic.xyz/v1/aave/reserves/main-ethereum-core-v4/0xe343167631d89b6ffc58b88d6b7fb0228795491d/latest',
+                    headers: { Authorization: `Bearer ${env.TOKENLOGIC_API_KEY}` },
                     extractors: [
                         {
                             type: 'path',
                             token: '0xac2435e3c25e8246870d33ce0a26988a46d5db68',
-                            path: '$.data[-1:].apyBase',
+                            path: '$.data[-1:].supply_apy',
                         },
                     ],
                 },

--- a/env.local
+++ b/env.local
@@ -7,6 +7,9 @@ ALCHEMY_API_KEY=
 SATSUMA_API_KEY=
 DRPC_API_KEY=
 
+# APRs
+TOKENLOGIC_API_KEY=
+
 # Database
 DATABASE_URL=postgresql://backend:let-me-in@localhost:5431/database?schema=public
 


### PR DESCRIPTION
Replaces the DeFiLlama feeds for the four Aave v4 Core waCore tokens on mainnet (added in #2623) with TokenLogic's official API, and adds two new Avalanche waCore feeds from the same source:

`GET https://api.tokenlogic.xyz/v1/aave/reserves/{marketKey}/{reserveAddress}/latest`

**Mainnet (`main-ethereum-core-v4`)**

| Token | Reserve (underlying) | Balancer token |
|---|---|---|
| waCoreUSDC | `0xa0b8…eb48` | `0x531e90a2376902de8915789fcc1075e3b0c153e7` |
| waCoreUSDT | `0xdac1…1ec7` | `0x5ec44a70f309854fe04d495cfe1b5da63dd1cc73` |
| waCoreGHO | `0x40d1…6c2f` | `0x58c14a5e061c9bc6926c5b853445290f296c2f7b` |
| waCoreUSDG | `0xe343…491d` | `0xac2435e3c25e8246870d33ce0a26988a46d5db68` |

**Avalanche (`main-avalanche-core-v4`)** — new

| Token | Reserve (underlying) | Balancer token |
|---|---|---|
| waCoreUSDC | `0xb97e…8a6e` | `0x01d7f7b7ce2123192fecc20bd1caf3e4d9e4c10d` |
| waCoreUSDT | `0x9702…a8c7` | `0x2e4ba06ff97e10d09fa4f5a270e97301eae729a9` |

Notes:
- Auth via `Authorization: Bearer ${TOKENLOGIC_API_KEY}` — new optional env var added to `apps/env.ts` and `env.local`; the secret is already in the `api-secrets` Secrets Manager entry.
- No `scale`: TokenLogic returns `supply_apy` as a fraction (DeFiLlama's `apyBase` was in percent).
- Reserve addresses in the URLs are lowercase — the API's path matching is case-sensitive (checksummed addresses return empty data).
- All six endpoints verified live: response shape `{ data: [row], lastUpdated }`, extractor `$.data[-1:].supply_apy` returns mainnet USDC 3.18% / USDT 3.36% / GHO 3.38% / USDG 1.10%, avalanche USDC 0.47% / USDT 1.41%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)